### PR TITLE
return data and errors acc. spec #7.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ luacov.*.out*
 /node_modules
 /package-lock.json
 *.mo
+.history
+.vscode

--- a/test/integration/graphql_test.lua
+++ b/test/integration/graphql_test.lua
@@ -1129,3 +1129,29 @@ function g.test_validation_non_null_argument_error()
             end
     )
 end
+
+function g.test_both_data_and_error_result()
+    local query = [[
+        { test(arg: "A") }
+    ]]
+
+    local function callback(_, args)
+        return args[1].value, {message = 'Simple error'}
+    end
+
+    local query_schema = {
+        ['test'] = {
+            kind = types.string.nonNull,
+            arguments = {
+                arg = types.string.nonNull,
+                arg2 = types.string,
+                arg3 = types.int,
+                arg4 = types.long,
+            },
+            resolve = callback,
+        }
+    }
+    local data, errors = check_request(query, query_schema)
+    t.assert_equals(data, {test = 'A'})
+    t.assert_equals(errors,  {{message = 'Simple error'}})
+end

--- a/test/integration/graphql_test.lua
+++ b/test/integration/graphql_test.lua
@@ -1131,12 +1131,13 @@ function g.test_validation_non_null_argument_error()
 end
 
 function g.test_both_data_and_error_result()
-    local query = [[
-        { test(arg: "A") }
-    ]]
+    local query = [[{
+        test_A: test(arg: "A")
+        test_B: test(arg: "B")
+    }]]
 
     local function callback(_, args)
-        return args[1].value, {message = 'Simple error'}
+        return args[1].value, {message = 'Simple error ' .. args[1].value}
     end
 
     local query_schema = {
@@ -1152,6 +1153,9 @@ function g.test_both_data_and_error_result()
         }
     }
     local data, errors = check_request(query, query_schema)
-    t.assert_equals(data, {test = 'A'})
-    t.assert_equals(errors,  {{message = 'Simple error'}})
+    t.assert_equals(data, {test_A = 'A', test_B = 'B'})
+    t.assert_equals(errors,  {
+        {message = 'Simple error A'},
+        {message = 'Simple error B'},
+    })
 end


### PR DESCRIPTION
According to http://spec.graphql.org/draft/#sec-Errors executor must be able to return data or errors or data and errors

closes #11 