### PR TITLE
Improve returning data and errors from request

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          tarantoolctl rocks install luatest 0.5.2
-          tarantoolctl rocks install luacheck 0.25.0
+          tarantoolctl rocks install luatest 0.5.5
+          tarantoolctl rocks install luacheck 0.26.0
           tarantoolctl rocks make
 
       - name: Run linter

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@
 .doctrees
 __pycache__
 /dev
-/tmp
+/tmp/*
+!/tmp/.keep
 doc
 release
 release-doc
@@ -27,4 +28,4 @@ luacov.*.out*
 /package-lock.json
 *.mo
 .history
-.vscode
+*.rock

--- a/.luacov
+++ b/.luacov
@@ -1,0 +1,6 @@
+statsfile = 'tmp/luacov.stats.out'
+reportfile = 'tmp/luacov.report.out'
+exclude = {
+    '/test/',
+    '/tmp/',
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+SHELL := /bin/bash
+
+.PHONY: .rocks
+.rocks: graphql-scm-1.rockspec Makefile
+		tarantoolctl rocks make
+		tarantoolctl rocks install luatest 0.5.5
+		tarantoolctl rocks install luacov 0.13.0
+		tarantoolctl rocks install luacheck 0.26.0
+
+.PHONY: lint
+lint:
+		if [ ! -d ".rocks" ]; then make .rocks; fi
+		.rocks/bin/luacheck .
+
+.PHONY: test
+test: 	lint
+		rm -f tmp/luacov*
+		.rocks/bin/luatest --verbose --coverage --shuffle group
+		.rocks/bin/luacov . && grep -A999 '^Summary' tmp/luacov.report.out
+
+.PHONY: clean
+clean:
+		rm -rf .rocks
+
+.PHONY: build
+build:	
+		if [ ! -d ".rocks" ]; then make .rocks; fi
+		tarantoolctl rocks make
+		tarantoolctl rocks pack graphql scm-1	

--- a/graphql/execute.lua
+++ b/graphql/execute.lua
@@ -313,7 +313,6 @@ end
 
 evaluateSelections = function(objectType, object, selections, context)
   local result = {}
-  local errors
   local err
   local fields = collectFields(objectType, selections, {}, {}, context)
   for _, field in ipairs(fields) do
@@ -322,14 +321,14 @@ evaluateSelections = function(objectType, object, selections, context)
     result[field.name], err = getFieldEntry(objectType, object, {field.selection},
                                        context)
     if err ~= nil then
-        errors = errors or {}
-        table.insert(errors, err)
+        context.errors = context.errors or {}
+        table.insert(context.errors, err)
     end
     if result[field.name] == nil then
         result[field.name] = box.NULL
     end
   end
-  return result, errors
+  return result, context.errors
 end
 
 local function execute(schema, tree, rootValue, variables, operationName)

--- a/graphql/execute.lua
+++ b/graphql/execute.lua
@@ -278,7 +278,7 @@ local function getFieldEntry(objectType, object, fields, context)
       if argument and argument.value then
           positions[pos] = {
               name=argument.name.value,
-              value=arguments[argument.name.value]
+              value=arguments[argument.name.value],
           }
           pos = pos + 1
       end
@@ -346,4 +346,6 @@ local function execute(schema, tree, rootValue, variables, operationName)
 end
 
 
-return {execute=execute}
+return {
+  execute=execute,
+}

--- a/graphql/introspection.lua
+++ b/graphql/introspection.lua
@@ -39,7 +39,7 @@ __Schema = types.object({
         kind = types.nonNull(types.list(types.nonNull(__Type))),
         resolve = function(schema)
           return util.values(schema:getTypeMap())
-        end
+        end,
       },
 
       queryType = {
@@ -47,7 +47,7 @@ __Schema = types.object({
         kind = __Type.nonNull,
         resolve = function(schema)
           return schema:getQueryType()
-        end
+        end,
       },
 
       mutationType = {
@@ -55,7 +55,7 @@ __Schema = types.object({
         kind = __Type,
         resolve = function(schema)
           return schema:getMutationType()
-        end
+        end,
       },
 
       subscriptionType = {
@@ -63,7 +63,7 @@ __Schema = types.object({
         kind = __Type,
         resolve = function(_)
             return nil
-        end
+        end,
       },
 
 
@@ -72,10 +72,10 @@ __Schema = types.object({
         kind = types.nonNull(types.list(types.nonNull(__Directive))),
         resolve = function(schema)
           return schema.directives
-        end
-      }
+        end,
+      },
     }
-  end
+  end,
 })
 
 __Directive = types.object({
@@ -111,15 +111,15 @@ __Directive = types.object({
           if directive.onInlineFragment then table.insert(res, 'INLINE_FRAGMENT') end
 
           return res
-        end
+        end,
       },
 
       args = {
         kind = types.nonNull(types.list(types.nonNull(__InputValue))),
-        resolve = resolveArgs
-      }
+        resolve = resolveArgs,
+      },
     }
-  end
+  end,
 })
 
 __DirectiveLocation = types.enum({
@@ -133,34 +133,34 @@ __DirectiveLocation = types.enum({
   values = {
     QUERY = {
       value = 'QUERY',
-      description = 'Location adjacent to a query operation.'
+      description = 'Location adjacent to a query operation.',
     },
 
     MUTATION = {
       value = 'MUTATION',
-      description = 'Location adjacent to a mutation operation.'
+      description = 'Location adjacent to a mutation operation.',
     },
 
     FIELD = {
       value = 'FIELD',
-      description = 'Location adjacent to a field.'
+      description = 'Location adjacent to a field.',
     },
 
     FRAGMENT_DEFINITION = {
       value = 'FRAGMENT_DEFINITION',
-      description = 'Location adjacent to a fragment definition.'
+      description = 'Location adjacent to a fragment definition.',
     },
 
     FRAGMENT_SPREAD = {
       value = 'FRAGMENT_SPREAD',
-      description = 'Location adjacent to a fragment spread.'
+      description = 'Location adjacent to a fragment spread.',
     },
 
     INLINE_FRAGMENT = {
       value = 'INLINE_FRAGMENT',
-      description = 'Location adjacent to an inline fragment.'
-    }
-  }
+      description = 'Location adjacent to an inline fragment.',
+    },
+  },
 })
 
 __Type = types.object({
@@ -205,7 +205,7 @@ __Type = types.object({
           end
 
           error('Unknown type ' .. kind)
-        end
+        end,
       },
 
       fields = {
@@ -213,8 +213,8 @@ __Type = types.object({
         arguments = {
           includeDeprecated = {
             kind = types.boolean,
-            defaultValue = false
-          }
+            defaultValue = false,
+          },
         },
         resolve = function(kind, arguments)
           if kind.__type == 'Object' or kind.__type == 'Interface' then
@@ -233,7 +233,7 @@ __Type = types.object({
           if kind.__type == 'Object' then
             return kind.interfaces or {}
           end
-        end
+        end,
       },
 
       possibleTypes = {
@@ -242,13 +242,13 @@ __Type = types.object({
           if kind.__type == 'Interface' or kind.__type == 'Union' then
             return context.schema:getPossibleTypes(kind)
           end
-        end
+        end,
       },
 
       enumValues = {
         kind = types.list(types.nonNull(__EnumValue)),
         arguments = {
-          includeDeprecated = { kind = types.boolean, defaultValue = false }
+          includeDeprecated = { kind = types.boolean, defaultValue = false },
         },
         resolve = function(kind, arguments)
           if kind.__type == 'Enum' then
@@ -256,7 +256,7 @@ __Type = types.object({
               return arguments.includeDeprecated or not value.deprecationReason
             end)
           end
-        end
+        end,
       },
 
       inputFields = {
@@ -265,14 +265,14 @@ __Type = types.object({
           if kind.__type == 'InputObject' then
             return util.values(kind.fields)
           end
-        end
+        end,
       },
 
       ofType = {
-        kind = __Type
-      }
+        kind = __Type,
+      },
     }
-  end
+  end,
 })
 
 __Field = types.object({
@@ -290,26 +290,26 @@ __Field = types.object({
 
       args = {
         kind = types.nonNull(types.list(types.nonNull(__InputValue))),
-        resolve = resolveArgs
+        resolve = resolveArgs,
       },
 
       type = {
         kind = __Type.nonNull,
         resolve = function(field)
           return field.kind
-        end
+        end,
       },
 
       isDeprecated = {
         kind = types.boolean.nonNull,
         resolve = function(field)
           return field.deprecationReason ~= nil
-        end
+        end,
       },
 
-      deprecationReason = types.string
+      deprecationReason = types.string,
     }
-  end
+  end,
 })
 
 __InputValue = types.object({
@@ -330,7 +330,7 @@ __InputValue = types.object({
         kind = types.nonNull(__Type),
         resolve = function(field)
           return field.kind
-        end
+        end,
       },
 
       defaultValue = {
@@ -338,10 +338,10 @@ __InputValue = types.object({
         description = 'A GraphQL-formatted string representing the default value for this input value.',
         resolve = function(inputVal)
           return inputVal.defaultValue and tostring(inputVal.defaultValue) -- TODO improve serialization a lot
-        end
-      }
+        end,
+      },
     }
-  end
+  end,
 })
 
 __EnumValue = types.object({
@@ -361,9 +361,9 @@ __EnumValue = types.object({
         kind = types.boolean.nonNull,
         resolve = function(enumValue) return enumValue.deprecationReason ~= nil end
       },
-      deprecationReason = types.string
+      deprecationReason = types.string,
     }
-  end
+  end,
 })
 
 __TypeKind = types.enum({
@@ -372,44 +372,44 @@ __TypeKind = types.enum({
   values = {
     SCALAR = {
       value = 'SCALAR',
-      description = 'Indicates this type is a scalar.'
+      description = 'Indicates this type is a scalar.',
     },
 
     OBJECT = {
       value = 'OBJECT',
-      description = 'Indicates this type is an object. `fields` and `interfaces` are valid fields.'
+      description = 'Indicates this type is an object. `fields` and `interfaces` are valid fields.',
     },
 
     INTERFACE = {
       value = 'INTERFACE',
-      description = 'Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.'
+      description = 'Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.',
     },
 
     UNION = {
       value = 'UNION',
-      description = 'Indicates this type is a union. `possibleTypes` is a valid field.'
+      description = 'Indicates this type is a union. `possibleTypes` is a valid field.',
     },
 
     ENUM = {
       value = 'ENUM',
-      description = 'Indicates this type is an enum. `enumValues` is a valid field.'
+      description = 'Indicates this type is an enum. `enumValues` is a valid field.',
     },
 
     INPUT_OBJECT = {
       value = 'INPUT_OBJECT',
-      description = 'Indicates this type is an input object. `inputFields` is a valid field.'
+      description = 'Indicates this type is an input object. `inputFields` is a valid field.',
     },
 
     LIST = {
       value = 'LIST',
-      description = 'Indicates this type is a list. `ofType` is a valid field.'
+      description = 'Indicates this type is a list. `ofType` is a valid field.',
     },
 
     NON_NULL = {
       value = 'NON_NULL',
-      description = 'Indicates this type is a non-null. `ofType` is a valid field.'
-    }
-  }
+      description = 'Indicates this type is a non-null. `ofType` is a valid field.',
+    },
+  },
 })
 
 local Schema = {
@@ -419,7 +419,7 @@ local Schema = {
   arguments = {},
   resolve = function(_, _, info)
     return info.schema
-  end
+  end,
 }
 
 local Type = {
@@ -427,11 +427,11 @@ local Type = {
   kind = __Type,
   description = 'Request the type information of a single type.',
   arguments = {
-    name = types.string.nonNull
+    name = types.string.nonNull,
   },
   resolve = function(_, arguments, info)
     return info.schema:getType(arguments.name)
-  end
+  end,
 }
 
 local TypeName = {
@@ -441,7 +441,7 @@ local TypeName = {
   arguments = {},
   resolve = function(_, _, info)
     return info.parentType.name
-  end
+  end,
 }
 
 return {
@@ -458,6 +458,6 @@ return {
   fieldMap = {
     __schema = Schema,
     __type = Type,
-    __typename = TypeName
-  }
+    __typename = TypeName,
+  },
 }

--- a/graphql/rules.lua
+++ b/graphql/rules.lua
@@ -162,7 +162,7 @@ function rules.unambiguousSelections(node, context)
         local fieldEntry = {
           parent = parentType,
           field = selection,
-          definition = definition
+          definition = definition,
         }
 
         validateField(key, fieldEntry)

--- a/graphql/schema.lua
+++ b/graphql/schema.lua
@@ -21,7 +21,7 @@ function schema.create(config, name)
 
   self.directives = self.directives or {
     types.include,
-    types.skip
+    types.skip,
   }
 
   self.typeMap = {}

--- a/graphql/types.lua
+++ b/graphql/types.lua
@@ -33,7 +33,7 @@ local function initFields(kind, fields)
       description = field.description,
       deprecationReason = field.deprecationReason,
       arguments = field.arguments or {},
-      resolve = kind == 'Object' and field.resolve or nil
+      resolve = kind == 'Object' and field.resolve or nil,
     }
   end
 
@@ -45,7 +45,7 @@ function types.nonNull(kind)
 
   return {
     __type = 'NonNull',
-    ofType = kind
+    ofType = kind,
   }
 end
 
@@ -54,7 +54,7 @@ function types.list(kind)
 
   local instance = {
     __type = 'List',
-    ofType = kind
+    ofType = kind,
   }
 
   instance.nonNull = types.nonNull(instance)
@@ -123,7 +123,7 @@ function types.object(config)
     description = config.description,
     isTypeOf = config.isTypeOf,
     fields = fields,
-    interfaces = config.interfaces
+    interfaces = config.interfaces,
   }
 
   instance.nonNull = types.nonNull(instance)
@@ -152,7 +152,7 @@ function types.interface(config)
     name = config.name,
     description = config.description,
     fields = fields,
-    resolveType = config.resolveType
+    resolveType = config.resolveType,
   }
 
   instance.nonNull = types.nonNull(instance)
@@ -176,7 +176,7 @@ function types.enum(config)
       name = name,
       description = entry.description,
       deprecationReason = entry.deprecationReason,
-      value = entry.value
+      value = entry.value,
     }
   end
 
@@ -187,7 +187,7 @@ function types.enum(config)
     values = values,
     serialize = function(name)
       return instance.values[name] and instance.values[name].value or name
-    end
+    end,
   }
 
   instance.nonNull = types.nonNull(instance)
@@ -204,7 +204,7 @@ function types.union(config)
   local instance = {
     __type = 'Union',
     name = config.name,
-    types = config.types
+    types = config.types,
   }
 
   instance.nonNull = types.nonNull(instance)
@@ -222,7 +222,7 @@ function types.inputObject(config)
     field = field.__type and { kind = field } or field
     fields[fieldName] = {
       name = fieldName,
-      kind = field.kind
+      kind = field.kind,
     }
   end
 
@@ -230,7 +230,7 @@ function types.inputObject(config)
     __type = 'InputObject',
     name = config.name,
     description = config.description,
-    fields = fields
+    fields = fields,
   }
 
   types.get_env(config.schema)[config.name] = instance
@@ -418,7 +418,7 @@ function types.directive(config)
     onField = config.onField,
     onFragmentDefinition = config.onFragmentDefinition,
     onFragmentSpread = config.onFragmentSpread,
-    onInlineFragment = config.onInlineFragment
+    onInlineFragment = config.onInlineFragment,
   }
 
   return instance
@@ -428,22 +428,22 @@ types.include = types.directive({
   name = 'include',
   description = 'Directs the executor to include this field or fragment only when the `if` argument is true.',
   arguments = {
-    ['if'] = { kind = types.boolean.nonNull, description = 'Included when true.'}
+    ['if'] = { kind = types.boolean.nonNull, description = 'Included when true.'},
   },
   onField = true,
   onFragmentSpread = true,
-  onInlineFragment = true
+  onInlineFragment = true,
 })
 
 types.skip = types.directive({
   name = 'skip',
   description = 'Directs the executor to skip this field or fragment when the `if` argument is true.',
   arguments = {
-    ['if'] = { kind = types.boolean.nonNull, description = 'Skipped when true.' }
+    ['if'] = { kind = types.boolean.nonNull, description = 'Skipped when true.' },
   },
   onField = true,
   onFragmentSpread = true,
-  onInlineFragment = true
+  onInlineFragment = true,
 })
 
 types.resolve = function(type_name_or_obj, schema)

--- a/graphql/validate.lua
+++ b/graphql/validate.lua
@@ -31,7 +31,7 @@ local visitors = {
       return node.definitions
     end,
 
-    rules = { rules.uniqueFragmentNames, exit = { rules.noUnusedFragments } }
+    rules = { rules.uniqueFragmentNames, exit = { rules.noUnusedFragments } },
   },
 
   operation = {
@@ -59,9 +59,9 @@ local visitors = {
       rules.variableDefaultValuesHaveCorrectType,
       exit = {
         rules.variablesAreUsed,
-        rules.variablesAreDefined
-      }
-    }
+        rules.variablesAreDefined,
+      },
+    },
   },
 
   selectionSet = {
@@ -69,7 +69,7 @@ local visitors = {
       return node.selections
     end,
 
-    rules = { rules.unambiguousSelections }
+    rules = { rules.unambiguousSelections },
   },
 
   field = {
@@ -120,8 +120,8 @@ local visitors = {
       rules.argumentsOfCorrectType,
       rules.requiredArgumentsPresent,
       rules.directivesAreDefined,
-      rules.variableUsageAllowed
-    }
+      rules.variableUsageAllowed,
+    },
   },
 
   inlineFragment = {
@@ -148,8 +148,8 @@ local visitors = {
     rules = {
       rules.fragmentHasValidType,
       rules.fragmentSpreadIsPossible,
-      rules.directivesAreDefined
-    }
+      rules.directivesAreDefined,
+    },
   },
 
   fragmentSpread = {
@@ -213,8 +213,8 @@ local visitors = {
       rules.fragmentSpreadTargetDefined,
       rules.fragmentSpreadIsPossible,
       rules.directivesAreDefined,
-      rules.variableUsageAllowed
-    }
+      rules.variableUsageAllowed,
+    },
   },
 
   fragmentDefinition = {
@@ -240,8 +240,8 @@ local visitors = {
     rules = {
       rules.fragmentHasValidType,
       rules.fragmentDefinitionHasNoCycles,
-      rules.directivesAreDefined
-    }
+      rules.directivesAreDefined,
+    },
   },
 
   argument = {
@@ -267,7 +267,7 @@ local visitors = {
       end)
     end,
 
-    rules = { rules.uniqueInputObjectFields }
+    rules = { rules.uniqueInputObjectFields },
   },
 
   inputObject = {
@@ -277,7 +277,7 @@ local visitors = {
       end)
     end,
 
-    rules = { rules.uniqueInputObjectFields }
+    rules = { rules.uniqueInputObjectFields },
   },
 
   list = {
@@ -289,14 +289,14 @@ local visitors = {
   variable = {
     enter = function(node, context)
       context.variableReferences[node.name.value] = true
-    end
+    end,
   },
 
   directive = {
     children = function(node, _)
       return node.arguments
-    end
-  }
+    end,
+  },
 }
 
 local function validate(schema, tree)
@@ -349,4 +349,6 @@ local function validate(schema, tree)
   return visit(tree)
 end
 
-return {validate=validate}
+return {
+  validate=validate,
+}

--- a/test/integration/graphql_test.lua
+++ b/test/integration/graphql_test.lua
@@ -1158,4 +1158,42 @@ function g.test_both_data_and_error_result()
         {message = 'Simple error A'},
         {message = 'Simple error B'},
     })
+
+    query = [[{
+        prefix {
+            test_A: test(arg: "A")
+            test_B: test(arg: "B")
+        }
+    }]]
+
+    query_schema = {
+        ['prefix'] = {
+            kind = types.object({
+                name = 'prefix',
+                fields = {
+                    ['test'] = {
+                        kind = types.string.nonNull,
+                        arguments = {
+                            arg = types.string.nonNull,
+                            arg2 = types.string,
+                            arg3 = types.int,
+                            arg4 = types.long,
+                        },
+                        resolve = callback,
+                    }
+                },
+            }),
+            arguments = {},
+            resolve = function()
+                return {}
+            end,
+        }
+    }
+
+    data, errors = check_request(query, query_schema)
+    t.assert_equals(data, {prefix = {test_A = 'A', test_B = 'B'}})
+    t.assert_equals(errors,  {
+        {message = 'Simple error A'},
+        {message = 'Simple error B'},
+    })
 end


### PR DESCRIPTION
https://github.com/tarantool/graphql/commit/32c97f0b30bae9bb27a178f7fb5ecba0e72d9985 introduced returning data and errors acc. spec tarantool#7.1.2 but previous implementation didn't  take in account that execution may include multiple resolvers and each of them may return both data and errors. This PR fixes the logic to collect all errors from all resolvers into single map that can be returned to requestor.