### PR TITLE
Support custom directives

### DIFF
--- a/graphql/execute.lua
+++ b/graphql/execute.lua
@@ -286,6 +286,36 @@ local function getFieldEntry(objectType, object, fields, context)
 
   arguments = setmetatable(arguments, {__index=positions})
 
+  local directiveMap = {}
+  for _, directive in ipairs(firstField.directives or {}) do
+    directiveMap[directive.name.value] = directive
+  end
+
+  local directives = {}
+
+  if next(directiveMap) ~= nil then
+    util.map_name(context.schema.directives or {}, function(directive, directive_name)
+      local supplied_directive = directiveMap[directive_name]
+      if supplied_directive == nil then
+        return nil
+      end
+
+      local directiveArgumentMap = {}
+      for _, argument in ipairs(supplied_directive.arguments or {}) do
+        directiveArgumentMap[argument.name.value] = argument
+      end
+
+      directives[directive_name] = util.map(directive.arguments or {}, function(argument, name)
+        local supplied = directiveArgumentMap[name] and directiveArgumentMap[name].value
+        if argument.kind then argument = argument.kind end
+        return util.coerceValue(supplied, argument, context.variables, {
+          strict_non_null = true,
+          defaultValues = defaultValues,
+        })
+      end)
+    end)
+  end
+
   local info = {
     context = context,
     fieldName = fieldName,
@@ -298,6 +328,7 @@ local function getFieldEntry(objectType, object, fields, context)
     operation = context.operation,
     variableValues = context.variables,
     defaultValues = context.defaultValues,
+    directives = directives,
   }
 
   local resolvedObject, err = (fieldType.resolve or defaultResolver)(object, arguments, info)

--- a/graphql/introspection.lua
+++ b/graphql/introspection.lua
@@ -109,6 +109,18 @@ __Directive = types.object({
           if directive.onFragmentDefinition then table.insert(res, 'FRAGMENT_DEFINITION') end
           if directive.onFragmentSpread then table.insert(res, 'FRAGMENT_SPREAD') end
           if directive.onInlineFragment then table.insert(res, 'INLINE_FRAGMENT') end
+          if directive.onVariableDefinition then table.insert(res, 'VARIABLE_DEFINITION') end
+          if directive.onSchema then table.insert(res, 'SCHEMA') end
+          if directive.onScalar then table.insert(res, 'SCALAR') end
+          if directive.onObject then table.insert(res, 'OBJECT') end
+          if directive.onFieldDefinition then table.insert(res, 'FIELD_DEFINITION') end
+          if directive.onArgumentDefinition then table.insert(res, 'ARGUMENT_DEFINITION') end
+          if directive.onInterface then table.insert(res, 'INTERFACE') end
+          if directive.onUnion then table.insert(res, 'UNION') end
+          if directive.onEnum then table.insert(res, 'ENUM') end
+          if directive.onEnumValue then table.insert(res, 'ENUM_VALUE') end
+          if directive.onInputObject then table.insert(res, 'INPUT_OBJECT') end
+          if directive.onInputFieldDefinition then table.insert(res, 'INPUT_FIELD_DEFINITION') end
 
           return res
         end,
@@ -117,6 +129,13 @@ __Directive = types.object({
       args = {
         kind = types.nonNull(types.list(types.nonNull(__InputValue))),
         resolve = resolveArgs,
+      },
+
+      isRepeatable = {
+        kind = types.nonNull(types.boolean),
+        resolve = function(directive)
+          return directive.isRepeatable == true
+        end,
       },
     }
   end,
@@ -159,6 +178,66 @@ __DirectiveLocation = types.enum({
     INLINE_FRAGMENT = {
       value = 'INLINE_FRAGMENT',
       description = 'Location adjacent to an inline fragment.',
+    },
+
+    VARIABLE_DEFINITION = {
+      value = 'VARIABLE_DEFINITION',
+      description = 'Location adjacent to a variable definition.',
+    },
+
+    SCHEMA = {
+      value = 'SCHEMA',
+      description = 'Location adjacent to schema.',
+    },
+
+    SCALAR = {
+      value = 'SCALAR',
+      description = 'Location adjacent to a scalar.',
+    },
+
+    OBJECT = {
+      value = 'OBJECT',
+      description = 'Location adjacent to an object.',
+    },
+
+    FIELD_DEFINITION = {
+      value = 'FIELD_DEFINITION',
+      description = 'Location adjacent to a field definition.',
+    },
+
+    ARGUMENT_DEFINITION = {
+      value = 'ARGUMENT_DEFINITION',
+      description = 'Location adjacent to an argument definition.',
+    },
+
+    INTERFACE = {
+      value = 'INTERFACE',
+      description = 'Location adjacent to an interface.',
+    },
+
+    UNION = {
+      value = 'UNION',
+      description = 'Location adjacent to an union.',
+    },
+
+    ENUM = {
+      value = 'ENUM',
+      description = 'Location adjacent to an enum.',
+    },
+
+    ENUM_VALUE = {
+      value = 'ENUM_VALUE',
+      description = 'Location adjacent to an enum value.',
+    },
+
+    INPUT_OBJECT = {
+      value = 'INPUT_OBJECT',
+      description = 'Location adjacent to an input object.',
+    },
+
+    INPUT_FIELD_DEFINITION = {
+      value = 'INPUT_FIELD_DEFINITION',
+      description = 'Location adjacent to an input field definition.',
     },
   },
 })

--- a/graphql/schema.lua
+++ b/graphql/schema.lua
@@ -99,6 +99,28 @@ end
 function schema:generateDirectiveMap()
   for _, directive in ipairs(self.directives) do
     self.directiveMap[directive.name] = directive
+    if directive.arguments ~= nil then
+      for name, argument in pairs(directive.arguments) do
+
+          -- BEGIN_HACK: resolve type names to real types
+          if type(argument) == 'string' then
+            argument = types.resolve(argument, self.name)
+            directive.arguments[name] = argument
+          end
+
+          if type(argument.kind) == 'string' then
+            argument.kind = types.resolve(argument.kind, self.name)
+          end
+          -- END_HACK: resolve type names to real types
+
+          local argumentType = argument.__type and argument or argument.kind
+          if argumentType == nil then
+            error('Must supply type for argument "' .. name .. '" on "' .. directive.name .. '"')
+          end
+          argumentType.defaultValue = argument.defaultValue
+          self:generateTypeMap(argumentType)
+      end
+    end
   end
 end
 

--- a/graphql/types.lua
+++ b/graphql/types.lua
@@ -419,6 +419,19 @@ function types.directive(config)
     onFragmentDefinition = config.onFragmentDefinition,
     onFragmentSpread = config.onFragmentSpread,
     onInlineFragment = config.onInlineFragment,
+    onVariableDefinition = config.onVariableDefinition,
+    onSchema = config.onSchema,
+    onScalar = config.onScalar,
+    onObject = config.onObject,
+    onFieldDefinition = config.onFieldDefinition,
+    onArgumentDefinition = config.onArgumentDefinition,
+    onInterface = config.onInterface,
+    onUnion = config.onUnion,
+    onEnum = config.onEnum,
+    onEnumValue = config.onEnumValue,
+    onInputObject = config.onInputObject,
+    onInputFieldDefinition = config.onInputFieldDefinition,
+    isRepeatable = config.isRepeatable or false,
   }
 
   return instance

--- a/graphql/util.lua
+++ b/graphql/util.lua
@@ -11,6 +11,16 @@ local function map(t, fn)
   return res
 end
 
+local function map_name(t, fn)
+  local res = {}
+  for _, v in pairs(t or {}) do
+    if v.name then
+      res[v.name] = fn(v, v.name)
+    end
+  end
+  return res
+end
+
 local function find(t, fn)
   for k, v in pairs(t) do
     if fn(v, k) then return v end
@@ -270,6 +280,7 @@ end
 
 return {
   map = map,
+  map_name = map_name,
   find = find,
   filter = filter,
   values = values,

--- a/test/integration/introspection.lua
+++ b/test/integration/introspection.lua
@@ -1,0 +1,98 @@
+return {
+      query = [[
+        query IntrospectionQuery {
+        __schema {
+            queryType { name }
+            mutationType { name }
+            subscriptionType { name }
+            types {
+            ...FullType
+            }
+            directives {
+            name
+            description
+            isRepeatable
+            locations
+            args {
+                ...InputValue
+            }
+            }
+        }
+        }
+
+        fragment FullType on __Type {
+            kind
+            name
+            description
+            specifiedByUrl
+            fields(includeDeprecated: true) {
+                name
+                description
+                args {
+                    ...InputValue
+                }
+                type {
+                    ...TypeRef
+                }
+                isDeprecated
+                deprecationReason
+            }
+            inputFields {
+                ...InputValue
+            }
+            interfaces {
+                ...TypeRef
+            }
+            enumValues(includeDeprecated: true) {
+                name
+                description
+                isDeprecated
+                deprecationReason
+            }
+            possibleTypes {
+                ...TypeRef
+            }
+        }
+
+        fragment InputValue on __InputValue {
+            name
+            description
+            type { ...TypeRef }
+            defaultValue
+        }
+
+        fragment TypeRef on __Type {
+        kind
+        name
+        ofType {
+            kind
+            name
+            ofType {
+            kind
+            name
+            ofType {
+                kind
+                name
+                ofType {
+                kind
+                name
+                ofType {
+                    kind
+                    name
+                    ofType {
+                    kind
+                    name
+                    ofType {
+                        kind
+                        name
+                    }
+                    }
+                }
+                }
+            }
+            }
+        }
+        }
+    ]],
+    variables = {}
+}

--- a/test/unit/graphql_test.lua
+++ b/test/unit/graphql_test.lua
@@ -1,10 +1,11 @@
 local t = require('luatest')
-local g = t.group()
+local g = t.group('unit')
 
 local parse = require('graphql.parse').parse
 local types = require('graphql.types')
 local schema = require('graphql.schema')
 local validate = require('graphql.validate').validate
+local util = require('graphql.util')
 
 function g.test_parse_comments()
     t.assert_error(parse('{a(b:"#")}').definitions, {})
@@ -1056,4 +1057,15 @@ function g.test_boolean_coerce()
             validate, test_schema, parse([[ { test_boolean(value: 123) } ]]))
     t.assert_error_msg_contains('Could not coerce value "value" with type "string" to type boolean',
             validate, test_schema, parse([[ { test_boolean(value: "value") } ]]))
+end
+
+function g.test_util_map_name()
+    local res = util.map_name(nil, nil)
+    t.assert_equals(res, {})
+
+    res = util.map_name({ { name = 'a' }, { name = 'b' }, }, function(v) return v end)
+    t.assert_equals(res, {a = {name = 'a'}, b = {name = 'b'}})
+
+    res = util.map_name({ entry_a = { name = 'a' }, entry_b = { name = 'b' }, }, function(v) return v end)
+    t.assert_equals(res, {a = {name = 'a'}, b = {name = 'b'}})
 end


### PR DESCRIPTION
GraphQL custom directives was introduced in [spec #3.13 in October 2021 release](https://spec.graphql.org/October2021/#sec-Type-System.Directives.Custom-Directives). Directives are the preferred way to extend GraphQL with custom or experimental behavior. This patch adds support of custom directives, as well as several location adjustments and repeatable directive option needed for full support of custom directives.

This patch also adds introspection test for schema with custom directives to validate schema. Introspection of schema is described in [spec #4.2](https://spec.graphql.org/October2021/#sec-Schema-Introspection).

Based on PR #20 by @no1seman . No major changes was introduced: minor syntax and test cases fixes, add commit message description, removed #18 and #19 commits.