### PR TITLE
Support scalar specification URL

### DIFF
--- a/graphql/introspection.lua
+++ b/graphql/introspection.lua
@@ -347,6 +347,15 @@ __Type = types.object({
         end,
       },
 
+      specifiedByUrl = {
+        kind = types.string,
+        resolve = function(kind)
+          if kind.__type == 'Scalar' then
+              return kind.specifiedByUrl
+          end
+        end,
+      },
+
       ofType = {
         kind = __Type,
       },

--- a/graphql/schema.lua
+++ b/graphql/schema.lua
@@ -22,6 +22,7 @@ function schema.create(config, name)
   self.directives = self.directives or {
     types.include,
     types.skip,
+    types.specifiedBy,
   }
 
   self.typeMap = {}

--- a/graphql/types.lua
+++ b/graphql/types.lua
@@ -97,6 +97,7 @@ function types.scalar(config)
     parseValue = config.parseValue,
     parseLiteral = config.parseLiteral,
     isValueOfTheType = config.isValueOfTheType,
+    specifiedByUrl = config.specifiedByUrl,
   }
 
   instance.nonNull = types.nonNull(instance)
@@ -457,6 +458,15 @@ types.skip = types.directive({
   onField = true,
   onFragmentSpread = true,
   onInlineFragment = true,
+})
+
+types.specifiedBy = types.directive({
+  name = 'specifiedBy',
+  description = 'Custom scalar specification.',
+  arguments = {
+    ['url'] = { kind = types.string.nonNull, description = 'Scalar specification URL.', }
+  },
+  onScalar = true,
 })
 
 types.resolve = function(type_name_or_obj, schema)

--- a/graphql/util.lua
+++ b/graphql/util.lua
@@ -27,6 +27,13 @@ local function find(t, fn)
   end
 end
 
+local function find_by_name(t, name)
+  for _, v in pairs(t or {}) do
+    if v.name == name then return v end
+  end
+  return nil
+end
+
 local function filter(t, fn)
   local res = {}
   for _,v in pairs(t) do
@@ -282,6 +289,7 @@ return {
   map = map,
   map_name = map_name,
   find = find,
+  find_by_name = find_by_name,
   filter = filter,
   values = values,
   compose = compose,

--- a/test/unit/graphql_test.lua
+++ b/test/unit/graphql_test.lua
@@ -1069,3 +1069,22 @@ function g.test_util_map_name()
     res = util.map_name({ entry_a = { name = 'a' }, entry_b = { name = 'b' }, }, function(v) return v end)
     t.assert_equals(res, {a = {name = 'a'}, b = {name = 'b'}})
 end
+
+function g.test_util_find_by_name()
+    local res = util.find_by_name({}, 'var')
+    t.assert_equals(res, nil)
+
+    res = util.find_by_name({ { name = 'avr' } }, 'var')
+    t.assert_equals(res, nil)
+
+    res = util.find_by_name({ { name = 'avr', value = 1 }, { name = 'var', value = 2 } }, 'var')
+    t.assert_equals(res, { name = 'var', value = 2 })
+
+    res = util.find_by_name(
+        {
+            entry1 = { name = 'avr', value = 1 },
+            entry2 = { name = 'var', value = 2 }
+        },
+        'var')
+    t.assert_equals(res, { name = 'var', value = 2 })
+end


### PR DESCRIPTION
Rework of #21 .

When defining a custom scalar, GraphQL services should provide a scalar specification URL via the `@specifiedBy` directive or the `specifiedByURL` introspection field ([spec. #3.5](https://spec.graphql.org/draft/#sec-Scalars.Custom-Scalars)). This patch introduces support of these tools.

Reworks: add test for directive, change directive name to `@specifiedBy` based on spec, add commit message.