### PR TITLE
Improve descriptions support

### DIFF
--- a/graphql/introspection.lua
+++ b/graphql/introspection.lua
@@ -7,7 +7,7 @@ local __Schema, __Directive, __DirectiveLocation, __Type, __Field, __InputValue,
 local function resolveArgs(field)
     local function transformArg(arg, name)
         if arg.__type then
-            return { kind = arg, name = name }
+            return { kind = arg, name = name, description = arg.description }
         elseif arg.name then
             return arg
         else

--- a/graphql/types.lua
+++ b/graphql/types.lua
@@ -224,6 +224,7 @@ function types.inputObject(config)
     fields[fieldName] = {
       name = fieldName,
       kind = field.kind,
+      description = field.description,
     }
   end
 


### PR DESCRIPTION
Rework of #22 .

Support descriptions in InputObject fields. Include descriptions in introspection output.

Rework: minor test reworks, rebase on modern branches.