### PR TITLE
Fix describing type with table in schema

### DIFF
--- a/graphql/execute.lua
+++ b/graphql/execute.lua
@@ -260,6 +260,13 @@ local function getFieldEntry(objectType, object, fields, context)
 
   local arguments = util.map(fieldType.arguments or {}, function(argument, name)
     local supplied = argumentMap[name] and argumentMap[name].value
+
+    -- This line of code provides support to using
+    -- `arg = { kind = type, description = desc }`
+    -- type declaration in query input arguments
+    -- instead of `arg = type` one.
+    if argument.kind then argument = argument.kind end
+
     return util.coerceValue(supplied, argument, context.variables, {
       strict_non_null = true,
       defaultValues = defaultValues,

--- a/graphql/rules.lua
+++ b/graphql/rules.lua
@@ -517,6 +517,13 @@ local function isVariableTypesValid(argument, argumentType, context,
       variableType = types.nonNull(variableType)
     end
 
+    -- This line of code provides support to using
+    -- `arg = { kind = type, description = desc }`
+    -- type declaration in query input arguments
+    -- instead of `arg = type` one when passing
+    -- argument with a variable.
+    if argumentType.kind ~= nil then argumentType = argumentType.kind end
+
     if not isTypeSubTypeOf(variableType, argumentType, context) then
       return false, ('Variable "%s" type mismatch: the variable type "%s" ' ..
         'is not compatible with the argument type "%s"'):format(variableName,

--- a/test/integration/graphql_test.lua
+++ b/test/integration/graphql_test.lua
@@ -1613,3 +1613,29 @@ function g.test_schema_input_arg_described_with_kind()
     local _, errors = check_request(query, query_schema, {})
     t.assert_equals(errors, nil)
 end
+
+function g.test_schema_input_arg_described_with_kind_variable_pass()
+    local function callback(_, args)
+        return args[1].value
+    end
+
+    local query_schema = {
+        ['test'] = {
+            kind = types.string.nonNull,
+            arguments = {
+                arg = {
+                    kind = types.string.nonNull,
+                },
+            },
+            resolve = callback,
+        }
+    }
+
+    local query = [[
+        query ($arg: String!) { test(arg: $arg) }
+    ]]
+    local variables = { arg = 'B' }
+
+    local _, errors = check_request(query, query_schema, nil, nil, { variables = variables })
+    t.assert_equals(errors, nil)
+end

--- a/test/integration/graphql_test.lua
+++ b/test/integration/graphql_test.lua
@@ -1588,3 +1588,28 @@ function g.test_descriptions()
     local input_object_arg_described = util.find_by_name(test_input_object.inputFields, 'input_object_arg_described')
     t.assert_equals(input_object_arg_described.description, 'input object argument')
 end
+
+function g.test_schema_input_arg_described_with_kind()
+    local function callback(_, args)
+        return args[1].value
+    end
+
+    local query_schema = {
+        ['test'] = {
+            kind = types.string.nonNull,
+            arguments = {
+                arg = {
+                    kind = types.string.nonNull,
+                },
+            },
+            resolve = callback,
+        }
+    }
+
+    local query = [[
+        { test(arg: "A") }
+    ]]
+
+    local _, errors = check_request(query, query_schema, {})
+    t.assert_equals(errors, nil)
+end


### PR DESCRIPTION
Rework of #22

Before this PR, describing argument type in schema with a table resulted in "No value provided" error on query execution and in "unsupported Lua type 'function'" error on variable type validation.

Reworks: introduce tests, separate from descriptions commit.