### PR TITLE
Fix coercing default values on schema generation

### DIFF
--- a/graphql/types.lua
+++ b/graphql/types.lua
@@ -224,6 +224,7 @@ function types.inputObject(config)
       name = fieldName,
       kind = field.kind,
       description = field.description,
+      defaultValue = field.defaultValue,
     }
   end
 


### PR DESCRIPTION
Before this patch:
- defaultValue were not saved on inputObject creation
- on schema generation defaultValue were not propagated

[x] Tests