### PR TITLE
Specify custom types description URL

### DIFF
--- a/graphql/types.lua
+++ b/graphql/types.lua
@@ -309,6 +309,7 @@ types.long = types.scalar({
   name = 'Long',
   description = "The `Long` scalar type represents non-fractional signed whole numeric values. " ..
           "Long can represent values from -(2^52) to 2^52 - 1, inclusive.",
+  specifiedByURL = 'https://github.com/tarantool/graphql/wiki/Long',
   serialize = coerceLong,
   parseLiteral = function(node)
     return coerceLong(node.value)
@@ -331,6 +332,8 @@ end
 
 types.float = types.scalar({
   name = 'Float',
+  description = "The `Float` scalar type represents signed double-"..
+          "precision fractional values as specified by IEEE 754.",
   serialize = coerceFloat,
   parseLiteral = function(node)
     return coerceFloat(node.value)

--- a/test/integration/graphql_test.lua
+++ b/test/integration/graphql_test.lua
@@ -1697,3 +1697,21 @@ function g.test_arguments_default_values()
     local nested_enum_arg_defaults = util.find_by_name(test_input_object.inputFields, 'nested_enum_arg_defaults')
     t.assert_equals(nested_enum_arg_defaults.defaultValue, 'write')
 end
+
+function g.test_specifiedByURL_long_scalar()
+    local query_schema = {
+        ['test'] = {
+            kind = types.string.nonNull,
+            arguments = {
+                arg = types.long,
+            },
+            resolve = '',
+        }
+    }
+
+    local data, errors = check_request(introspection.query, query_schema)
+    local long_type_schema = util.find_by_name(data.__schema.types, 'Long')
+    t.assert_type(long_type_schema, 'table', 'Long scalar type found on introspection')
+    t.assert_equals(long_type_schema.specifiedByURL, 'https://github.com/tarantool/graphql/wiki/Long')
+    t.assert_equals(errors, nil)
+end


### PR DESCRIPTION
Specify custom types description URL according to spec: http://spec.graphql.org/October2021/#sec-Schema-Introspection.Schema-Introspection-Schema

closes: https://github.com/tarantool/graphql/issues/30