### PR TITLE
Rename defaultValues to variablesDefaultValues in execute.getFieldEntry()

### DIFF
--- a/graphql/execute.lua
+++ b/graphql/execute.lua
@@ -247,12 +247,12 @@ local function getFieldEntry(objectType, object, fields, context)
     argumentMap[argument.name.value] = argument
   end
 
-  local defaultValues = {}
+  local variablesDefaultValues = {}
   if context.operation.variableDefinitions ~= nil then
     for _, value in ipairs(context.operation.variableDefinitions) do
       if value.defaultValue ~= nil then
         local variableType = query_util.typeFromAST(value.type, context.schema)
-        defaultValues[value.variable.name.value] = util.coerceValue(value.defaultValue, variableType)
+        variablesDefaultValues[value.variable.name.value] = util.coerceValue(value.defaultValue, variableType)
       end
     end
   end
@@ -268,7 +268,7 @@ local function getFieldEntry(objectType, object, fields, context)
 
     return util.coerceValue(supplied, argument, context.variables, {
       strict_non_null = true,
-      defaultValues = defaultValues,
+      defaultValues = variablesDefaultValues,
     })
   end)
 
@@ -316,7 +316,7 @@ local function getFieldEntry(objectType, object, fields, context)
         if argument.kind then argument = argument.kind end
         return util.coerceValue(supplied, argument, context.variables, {
           strict_non_null = true,
-          defaultValues = defaultValues,
+          defaultValues = variablesDefaultValues,
         })
       end)
     end)

--- a/test/integration/graphql_test.lua
+++ b/test/integration/graphql_test.lua
@@ -1425,6 +1425,17 @@ function g.test_custom_directives()
     data, errors = check_request(query, query_schema, nil, directives)
     t.assert_equals(data, { test_G = '{"num":5,"str":"news"}' })
     t.assert_equals(errors, nil)
+
+    -- check custom directives with variables
+    local variables = {num = 33}
+
+    query = [[query TEST($num: Int, $str: String = "variable") {
+        test_G: test(arg: { num: 2, str: "s" })@override_v2(arg: { num: $num, str: $str })
+    }]]
+
+    data, errors = check_request(query, query_schema, nil, directives, {variables = variables})
+    t.assert_equals(data, { test_G = '{"num":33,"str":"variable"}' })
+    t.assert_equals(errors, nil)
 end
 
 function g.test_specifiedByURL_scalar_field()


### PR DESCRIPTION
According to GraphQL spec it's possible to point a value of variable not only in variables map but inline it into request itself, for example:

query TEST($num: Int, $str: String = "variable") {
    test_G: test(arg: { num: $num, str: $str })
}

Thus in this PR `defaultValues` in execute.getFieldEntry() renamed to `variablesDefaultValues` to be more clear for anyone who reading sources.

Also added test to check the same semantic for custom directives: 
query TEST($num: Int, $str: String = "variable")
{
    test_G: test(arg: { num: 2, str: "s" })@override_v2(arg: { num: $num, str: $str })
}