### PR TITLE
Fix schema typeMap damaging on directiveMap generation

### DIFF
--- a/graphql/schema.lua
+++ b/graphql/schema.lua
@@ -117,7 +117,6 @@ function schema:generateDirectiveMap()
           if argumentType == nil then
             error('Must supply type for argument "' .. name .. '" on "' .. directive.name .. '"')
           end
-          argumentType.defaultValue = argument.defaultValue
           self:generateTypeMap(argumentType)
       end
     end


### PR DESCRIPTION
Remove forcing defaultValue on directiveMap generation because it leads to adding redundant defaultValue field to Scalars itself into typeMap:

```json
{
    "typeMap": {
        "Int": {
            "defaultValue": 1, <- ERROR
            "parseLiteral": "function: 0x415a8fe8",
            "__type": "Scalar",
            "nonNull": {},
            "serialize": "function: 0x415a8ed8",
            "isValueOfTheType": "function: 0x415a8e98",
            "name": "Int",
            "description": "..."
        }
    }
}
```

Here is a simple test (without this fix it fails):
```lua
function g.test_arguments_default_values_bug()
    local function callback(_, _)
        return nil
    end

    local mutation_schema = {
        ['test_mutation'] = {
            kind = types.string.nonNull,
            arguments = {
                object_arg = {
                    kind = types.inputObject({
                        name = 'test_input_object',
                        fields = {
                            nested = {
                                kind = types.string,
                                defaultValue = 'default Value',
                            },
                        },
                        kind = types.string,
                    }),
                },
                mutation_arg = {
                    kind = types.int,
                    defaultValue = 1,
                },

            },
            resolve = callback,
        }
    }

    local directives = {
        types.directive({
            schema = schema,
            name = 'timeout',
            arguments = {
                seconds = {
                    kind = types.int,
                    description = 'Request timeout (in seconds). Default: 1 second',
                    defaultValue = 1,
                },
            },
            onField = true,
        })
    }

    local root = {
        query = types.object({
            name = 'Query',
            fields = {},
        }),
        mutation = types.object({
            name = 'Mutation',
            fields = mutation_schema or {},
        }),
        directives = directives,
    }

    local compiled_schema = schema.create(root, test_schema_name)


    t.assert_equals(compiled_schema.typeMap['Int'].defaultValue, nil)
end
```