### PR TITLE
Accept cdata number as float and forbid NaN/Inf

### DIFF
--- a/graphql/types.lua
+++ b/graphql/types.lua
@@ -318,7 +318,15 @@ types.long = types.scalar({
 })
 
 local function isFloat(value)
-  return type(value) == 'number'
+  if type(value) == 'number' then
+    return true
+  end
+
+  if type(value) == 'cdata' then
+    return ffi.istype('int64_t', value) or ffi.istype('uint64_t', value)
+  end
+
+  return false
 end
 
 local function coerceFloat(value)

--- a/graphql/types.lua
+++ b/graphql/types.lua
@@ -317,9 +317,20 @@ types.long = types.scalar({
   isValueOfTheType = isLong,
 })
 
+-- Return `false` for NaN, Negative Infinity or Positive Infinity.
+-- Return `true` otherwise.
+local function isfinite(n)
+  local d = n - n
+  return n == n and d == d
+end
+
 local function isFloat(value)
+  -- http://spec.graphql.org/October2021/#sec-Float
+  --
+  -- > Non-finite floating-point internal values (NaN and Infinity) cannot be
+  -- > coerced to Float and must raise a field error.
   if type(value) == 'number' then
-    return true
+    return isfinite(value)
   end
 
   if type(value) == 'cdata' then


### PR DESCRIPTION
This pull request contains two changes related to processing of variables of the `Float` type.

## Accept a cdata number as value of a Float variable

It is quite usual that a floating point number is encoded using JSON, goes over HTTP, received on tarantool server, decoded from JSON and passed as a variable into the GraphQL executor.

A number out of the [-10^14+1; 10^14-1] range is decoded into Lua as cdata number[^1] to don't loss the precision. A JSON decoder don't know that we intend to use this value as the floating point one and chooses the conservative option: decode the value into cdata number to don't loss the precision.

[^1]: `cdata<int64_t>` or `cdata<uint64_t>`

In GraphQL we know that it is actually the floating point value (disregarding its representation in Lua). So it looks correct to accept a cdata number as value of a Float variable.

The similar idea was expressed in https://github.com/tarantool/tarantool/issues/5933 against tarantool itself: let it accept a number without fractional part as a value suitable for the `float` field type.

## Forbid NaN and Infinity as a value Float type

The GraphQL specification explicitly forbids it: 

> Non-finite floating-point internal values (NaN and Infinity) cannot
> be coerced to Float and must raise a field error.

http://spec.graphql.org/October2021/#sec-Float

----

Fixes #47
Supersedes PR #48