### PR TITLE
Fix rockspec and version injection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
           tarantool-version: '2.8'
 
       - run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
-      - run: echo "return { VERSION = '"$TAG"-1' }" > graphql/init.lua
+      - run: echo "return {VERSION = '"$TAG"'}" > graphql/init.lua
       - run: tarantoolctl rocks new_version --tag $TAG
       - run: tarantoolctl rocks make graphql-$TAG-1.rockspec
       - run: tarantoolctl rocks pack graphql $TAG

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,21 @@ name: Publish
 
 on:
   push:
-    tags:
-      - '*'
+    branches: [master]
+    tags: ['*']
 
 jobs:
-  publish:
+  publish-rockspec-scm-1:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: tarantool/rocks.tarantool.org/github-action@master
+        with:
+          auth: ${{ secrets.ROCKS_AUTH }}
+          files: graphql-scm-1.rockspec
+
+  publish-rockspec-tag:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,11 +18,12 @@ jobs:
       - run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - run: echo "return { VERSION = '"$TAG"-1' }" > graphql/init.lua
       - run: tarantoolctl rocks new_version --tag $TAG
-      - run: tarantoolctl rocks pack graphql-$TAG-1.rockspec
+      - run: tarantoolctl rocks make graphql-$TAG-1.rockspec
+      - run: tarantoolctl rocks pack graphql $TAG
 
       - uses: tarantool/rocks.tarantool.org/github-action@master
         with:
           auth: ${{ secrets.ROCKS_AUTH }}
           files: |
             graphql-${{ env.TAG }}-1.rockspec
-            graphql-${{ env.TAG }}-1.src.rock
+            graphql-${{ env.TAG }}-1.all.rock

--- a/graphql-scm-1.rockspec
+++ b/graphql-scm-1.rockspec
@@ -20,6 +20,7 @@ dependencies = {
 build = {
   type = 'builtin',
   modules = {
+    ['graphql.init'] = 'graphql/init.lua',
     ['graphql.execute'] = 'graphql/execute.lua',
     ['graphql.introspection'] = 'graphql/introspection.lua',
     ['graphql.parse'] = 'graphql/parse.lua',

--- a/graphql/init.lua
+++ b/graphql/init.lua
@@ -1,1 +1,1 @@
-return { VERSION = 'scm-1' }
+return {VERSION = 'unknown'}

--- a/test/unit/graphql_test.lua
+++ b/test/unit/graphql_test.lua
@@ -1090,5 +1090,5 @@ function g.test_util_find_by_name()
 end
 
 g.test_version = function()
-    t.assert_equals(require('graphql').VERSION, 'scm-1')
+    t.assert_type(require('graphql').VERSION, 'string')
 end


### PR DESCRIPTION
This patchset should actually finish the implementatoin of the `graphql.VERSION` string generation.

Follows up #29.