### PR TITLE
Fix returning gapped arrays

### DIFF
--- a/graphql/execute.lua
+++ b/graphql/execute.lua
@@ -208,7 +208,7 @@ local function completeValue(fieldType, result, subSelections, context, opts)
 
     local innerType = fieldType.ofType
     local values = {}
-    for i, value in ipairs(result) do
+    for i, value in pairs(result) do
       values[i] = completeValue(innerType, value, subSelections, context)
     end
 

--- a/graphql/util.lua
+++ b/graphql/util.lua
@@ -228,37 +228,23 @@ local function check(obj, obj_name, type_1, type_2, type_3)
     end
 end
 
---- Check whether table is an array.
----
---- Based on [that][1] implementation.
---- [1]: https://github.com/mpx/lua-cjson/blob/db122676/lua/cjson/util.lua
----
---- @tparam table table to check
---- @return[1] `true` if passed table is an array (includes the empty table
---- case)
---- @return[2] `false` otherwise
-local function is_array(table)
-    if type(table) ~= 'table' then
+local function is_array(t)
+  if type(t) ~= 'table' then
+     return false
+  end
+  local n = #t
+  if n > 0 then
+     for k in next, t, n do
+        if type(k) ~= 'number' or k < 0 then return false end
+     end
+     return true
+  end
+  for k in pairs(t) do
+     if type(k) ~= 'number' or k < 0 then
         return false
     end
-
-    local max = 0
-    local count = 0
-    for k, _ in pairs(table) do
-        if type(k) == 'number' then
-            if k > max then
-                max = k
-            end
-            count = count + 1
-        else
-            return false
-        end
-    end
-    if max > count * 2 then
-        return false
-    end
-
-    return max >= 0
+  end
+  return true
 end
 
 -- Copied from tarantool/tap

--- a/test/unit/graphql_test.lua
+++ b/test/unit/graphql_test.lua
@@ -1092,3 +1092,18 @@ end
 g.test_version = function()
     t.assert_type(require('graphql').VERSION, 'string')
 end
+
+function g.test_is_array()
+    t.assert_equals(util.is_array({[3] = 'a', [1] = 'b', [6] = 'c'}), true)
+    t.assert_equals(util.is_array({[3] = 'a', [1] = 'b', [7] = 'c'}), true)
+    t.assert_equals(util.is_array({[3] = 'a', nil, [6] = 'c'}), true)
+    t.assert_equals(util.is_array({[3] = 'a', nil, [7] = 'c'}), true)
+    t.assert_equals(util.is_array({[0] = 'a', [1] = 'b', [6] = 'c'}), true)
+    t.assert_equals(util.is_array({[-1] = 'a', [1] = 'b', [6] = 'c'}), false)
+    t.assert_equals(util.is_array({[3] = 'a', b = 'b', [6] = 'c'}), false)
+    t.assert_equals(util.is_array({}), true)
+    t.assert_equals(util.is_array(), false)
+    t.assert_equals(util.is_array(''), false)
+    t.assert_equals(util.is_array({a = 'a', b = 'b', c = 'c'}), false)
+    t.assert_equals(util.is_array({a = 'a', nil, c = 'c'}), false)
+end


### PR DESCRIPTION
For more details refer to linked issue.

Note: is_array() allows all positive key numbers including zero (for example id of primary key is zero and seems we have to support such cases too). 

closes: https://github.com/tarantool/graphql/issues/57