### PR TITLE
Argument and variables nullability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ coverage_result.txt
 .DS_Store
 .vscode
 luacov.*.out*
-/node_modules
+**/node_modules
 /package-lock.json
 *.mo
 .history

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -8,6 +8,7 @@ include_files = {
 }
 exclude_files = {
     '.rocks',
+    'test/integration/fuzzing_nullability_test.lua',
 }
 new_read_globals = {
     box = { fields = {

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 .PHONY: .rocks
 .rocks: graphql-scm-1.rockspec Makefile
 		tarantoolctl rocks make
-		tarantoolctl rocks install luatest 0.5.5
+		tarantoolctl rocks install luatest 0.5.7
 		tarantoolctl rocks install luacov 0.13.0
 		tarantoolctl rocks install luacheck 0.26.0
 

--- a/graphql/execute.lua
+++ b/graphql/execute.lua
@@ -193,7 +193,7 @@ local function completeValue(fieldType, result, subSelections, context, opts)
   end
 
   if result == nil then
-    return nil
+    return result
   end
 
   if fieldTypeName == 'List' then

--- a/graphql/execute.lua
+++ b/graphql/execute.lua
@@ -176,7 +176,7 @@ local function completeValue(fieldType, result, subSelections, context, opts)
     local innerType = fieldType.ofType
     local completedResult = completeValue(innerType, result, subSelections, context, opts)
 
-    if completedResult == nil then
+    if type(completedResult) == 'nil' then
       local err = string.format(
         'No value provided for non-null %s %q',
         (innerType.name or innerType.__type),

--- a/graphql/rules.lua
+++ b/graphql/rules.lua
@@ -408,11 +408,9 @@ end
 function rules.variableDefaultValuesHaveCorrectType(node, context)
   if node.variableDefinitions then
     for _, definition in ipairs(node.variableDefinitions) do
-      if definition.type.kind == 'nonNullType' and definition.defaultValue then
-        error('Non-null variables can not have default values')
-      elseif definition.defaultValue then
+      if definition.defaultValue then
         local variableType = query_util.typeFromAST(definition.type, context.schema)
-        util.coerceValue(definition.defaultValue, variableType)
+        util.coerceValue(definition.defaultValue, variableType, nil, coerce_opts)
       end
     end
   end

--- a/graphql/rules.lua
+++ b/graphql/rules.lua
@@ -198,13 +198,15 @@ function rules.uniqueArgumentNames(node, _)
   end
 end
 
+local coerce_opts = { strict_non_null = true, skip_variables = true }
+
 function rules.argumentsOfCorrectType(node, context)
   if node.arguments then
     local parentField = getParentField(context, node.name.value)
     for _, argument in pairs(node.arguments) do
       local name = argument.name.value
       local argumentType = parentField.arguments[name]
-      util.coerceValue(argument.value, argumentType.kind or argumentType)
+      util.coerceValue(argument.value, argumentType.kind or argumentType, nil, coerce_opts)
     end
   end
 end

--- a/graphql/rules.lua
+++ b/graphql/rules.lua
@@ -507,12 +507,13 @@ local function isVariableTypesValid(argument, argumentType, context,
       error('Unknown variable "' .. variableName .. '"')
     end
 
-    local hasDefault = variableDefinition.defaultValue ~= nil
+    local hasNonNullDefault = (variableDefinition.defaultValue ~= nil) and
+                              (variableDefinition.defaultValue.kind ~= 'null')
 
     local variableType = query_util.typeFromAST(variableDefinition.type,
       context.schema)
 
-    if hasDefault and variableType.__type ~= 'NonNull' then
+    if hasNonNullDefault and variableType.__type ~= 'NonNull' then
       variableType = types.nonNull(variableType)
     end
 

--- a/graphql/rules.lua
+++ b/graphql/rules.lua
@@ -513,6 +513,7 @@ local function isVariableTypesValid(argument, argumentType, context,
     local variableType = query_util.typeFromAST(variableDefinition.type,
       context.schema)
 
+    local realVariableTypeName = util.getTypeName(variableType)
     if hasNonNullDefault and variableType.__type ~= 'NonNull' then
       variableType = types.nonNull(variableType)
     end
@@ -527,7 +528,7 @@ local function isVariableTypesValid(argument, argumentType, context,
     if not isTypeSubTypeOf(variableType, argumentType, context) then
       return false, ('Variable "%s" type mismatch: the variable type "%s" ' ..
         'is not compatible with the argument type "%s"'):format(variableName,
-        util.getTypeName(variableType), util.getTypeName(argumentType))
+        realVariableTypeName, util.getTypeName(argumentType))
     end
   elseif argument.value.kind == 'list' then
     -- find variables deeper

--- a/graphql/util.lua
+++ b/graphql/util.lua
@@ -83,7 +83,12 @@ local function coerceValue(node, schemaType, variables, opts)
   variables = variables or {}
   opts = opts or {}
   local strict_non_null = opts.strict_non_null or false
+  local skip_variables = opts.skip_variables or false
   local defaultValues = opts.defaultValues or {}
+
+  if node and node.kind == 'variable' and skip_variables then
+    return nil
+  end
 
   if schemaType.__type == 'NonNull' then
     local res = coerceValue(node, schemaType.ofType, variables, opts)

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -1,0 +1,36 @@
+local types = require('graphql.types')
+local schema = require('graphql.schema')
+local parse = require('graphql.parse')
+local validate = require('graphql.validate')
+local execute = require('graphql.execute')
+
+local helpers = {}
+
+helpers.test_schema_name = 'default'
+
+function helpers.check_request(query, query_schema, mutation_schema, directives, opts)
+    opts = opts or {}
+    local root = {
+        query = types.object({
+            name = 'Query',
+            fields = query_schema or {},
+        }),
+        mutation = types.object({
+            name = 'Mutation',
+            fields = mutation_schema or {},
+        }),
+        directives = directives,
+    }
+
+    local compiled_schema = schema.create(root, helpers.test_schema_name, opts)
+
+    local parsed = parse.parse(query)
+
+    validate.validate(compiled_schema, parsed)
+
+    local rootValue = {}
+    local variables = opts.variables or {}
+    return execute.execute(compiled_schema, parsed, rootValue, variables)
+end
+
+return helpers

--- a/test/integration/codegen/fuzzing_nullability/README.md
+++ b/test/integration/codegen/fuzzing_nullability/README.md
@@ -1,0 +1,10 @@
+To install dependencies, run
+```bash
+npm install
+```
+
+To generate test file, run
+```bash
+node generate.js > ../../fuzzing_nullability_test.lua
+```
+in this directory.

--- a/test/integration/codegen/fuzzing_nullability/generate.js
+++ b/test/integration/codegen/fuzzing_nullability/generate.js
@@ -1,0 +1,906 @@
+const { graphql, buildSchema } = require('graphql');
+
+const nil = 'nil'
+const box = {NULL: 'box.NULL'}
+
+const Nullable = 'Nullable'
+const NonNullable = 'NonNullable'
+
+const graphql_types = {
+    "boolean_true": {
+        "var_type": 'Boolean',
+        "value": true,
+        "default": false,
+    },
+    "boolean_false": {
+        "var_type": 'Boolean',
+        "value": false,
+        "default": true,
+    },
+    "float": {
+        "var_type": 'Float',
+        "value": 1.1111111,
+        "default": 0,
+    },
+    "int": {
+        "var_type": 'Int',
+        "value": 2**30,
+        "default": 0,
+    },
+    "id": {
+        "var_type": 'ID',
+        "value": '00000000-0000-0000-0000-000000000000',
+        "default": '11111111-1111-1111-1111-111111111111',
+    },
+    "enum": {
+        "graphql_type": `
+        enum MyEnum {
+            a
+            b
+        }
+        `,
+        "var_type": 'MyEnum',
+        "value": `b`,
+        "default": `a`,
+    },
+}
+
+const Lua_to_JS_error = [
+    {
+        "regex": /^"Expected value of type \\\"(?<type>[a-zA-Z]+)\!\\\", found null\."$/,
+        "return": function(groups) {
+            return `"Expected non-null for \\\"NonNull(${groups.type})\\\", got null"`
+        }
+    },
+    {
+        "regex": /^"Expected value of type \\\"\[(?<type>[a-zA-Z]+)\]\!\\\", found null\."$/,
+        "return": function(groups) {
+            return `"Expected non-null for \\\"NonNull(List(${groups.type}))\\\", got null"`
+        }
+    },
+    {
+        "regex": /^"Expected value of type \\\"\[(?<type>[a-zA-Z]+)\!\]\\\", found null\."$/,
+        "return": function(groups) {
+            return `"Expected non-null for \\\"List(NonNull(${groups.type}))\\\", got null"`
+        }
+    },
+    {
+        "regex": /^"Expected value of type \\\"\[(?<type>[a-zA-Z]+)\!\]\!\\\", found null\."$/,
+        "return": function(groups) {
+            return `"Expected non-null for \\\"NonNull(List(NonNull(${groups.type})))\\\", got null"`
+        }
+    },
+    {
+        "regex": /^"Variable \\\"\$var1\\\" of required type \\\"(?<type>[a-zA-Z]+)\!\\\" was not provided\."$/,
+        "return": function(groups) {
+            return `"Variable \\\"var1\\\" expected to be non-null"`
+        }
+    },
+    {
+        "regex": /^"Variable \\\"\$var1\\\" of non-null type \\\"(?<type>[a-zA-Z]+)\!\\\" must not be null\."$/,
+        "return": function(groups) {
+            return `"Variable \\\"var1\\\" expected to be non-null"`
+        }
+    },
+    {
+        "regex": /^"Variable \\\"\$var1\\\" of type \\\"(?<type1>[a-zA-Z]+)\\\" used in position expecting type \\\"(?<type2>[a-zA-Z]+)\!\\\"\."$/,
+        "return": function(groups) {
+            return `"Variable \\\"var1\\\" type mismatch: the variable type \\\"${groups.type1}\\\" is not compatible with the argument type \\\"NonNull(${groups.type2})\\\""`
+        }
+    },
+    {
+        "regex": /^"Variable \\\"\$var1\\\" got invalid value null at \\\"var1\[0\]\\\"; Expected non-nullable type \\\"(?<type>[a-zA-Z]+)\!\\\" not to be null\."$/,
+        "return": function(groups) {
+            return `"Variable \\\"var1[1]\\\" expected to be non-null"`
+        }
+    },
+    {
+        "regex": /^"Variable \\\"\$var1\\\" of non-null type \\\"\[(?<type>[a-zA-Z]+)\!\]\!\\\" must not be null\."$/,
+        "return": function(groups) {
+            return `"Variable \\\"var1\\\" expected to be non-null"`
+        }
+    },
+    {
+        "regex": /^"Variable \\\"\$var1\\\" of required type \\\"\[(?<type>[a-zA-Z]+)\!\]\!\\\" was not provided\."$/,
+        "return": function(groups) {
+            return `"Variable \\\"var1\\\" expected to be non-null"`
+        }
+    },
+    {
+        "regex": /^"Variable \\\"\$var1\\\" of type \\\"\[(?<type1>[a-zA-Z]+)\]\!\\\" used in position expecting type \\\"\[(?<type2>[a-zA-Z]+)\!\]\!\\\"\."$/,
+        "return": function(groups) {
+            return `"Variable \\\"var1\\\" type mismatch: the variable type \\\"NonNull(List(${groups.type1}))\\\" is not compatible with the argument type \\\"NonNull(List(NonNull(${groups.type2})))\\\""`
+        }
+    },
+    {
+        "regex": /^"Variable \\\"\$var1\\\" of type \\\"\[(?<type1>[a-zA-Z]+)\!\]\\\" used in position expecting type \\\"\[(?<type2>[a-zA-Z]+)\!\]\!\\\"\."$/,
+        "return": function(groups) {
+            return `"Variable \\\"var1\\\" type mismatch: the variable type \\\"List(NonNull(${groups.type1}))\\\" is not compatible with the argument type \\\"NonNull(List(NonNull(${groups.type2})))\\\""`
+        }
+    },
+    {
+        "regex": /^"Variable \\\"\$var1\\\" of type \\\"\[(?<type1>[a-zA-Z]+)\]\\\" used in position expecting type \\\"\[(?<type2>[a-zA-Z]+)\!\]\!\\\"\."$/,
+        "return": function(groups) {
+            return `"Variable \\\"var1\\\" type mismatch: the variable type \\\"List(${groups.type1})\\\" is not compatible with the argument type \\\"NonNull(List(NonNull(${groups.type2})))\\\""`
+        }
+    },
+    {
+        "regex": /^"Variable \\\"\$var1\\\" of non-null type \\\"\[(?<type1>[a-zA-Z]+)\]\!\\\" must not be null\."$/,
+        "return": function(groups) {
+            return `"Variable \\\"var1\\\" expected to be non-null"`
+        }
+    },
+    {
+        "regex": /^"Variable \\\"\$var1\\\" of required type \\\"\[(?<type1>[a-zA-Z]+)\]\!\\\" was not provided\."$/,
+        "return": function(groups) {
+            return `"Variable \\\"var1\\\" expected to be non-null"`
+        }
+    },
+    {
+        "regex": /^"Variable \\\"\$var1\\\" of type \\\"\[(?<type1>[a-zA-Z]+)\!\]\\\" used in position expecting type \\\"\[(?<type2>[a-zA-Z]+)\]\!\\\"\."$/,
+        "return": function(groups) {
+            return `"Variable \\\"var1\\\" type mismatch: the variable type \\\"List(NonNull(${groups.type1}))\\\" is not compatible with the argument type \\\"NonNull(List(${groups.type2}))\\\""`
+        }
+    },
+    {
+        "regex": /^"Variable \\\"\$var1\\\" of type \\\"\[(?<type1>[a-zA-Z]+)\]\\\" used in position expecting type \\\"\[(?<type2>[a-zA-Z]+)\]\!\\\"\."$/,
+        "return": function(groups) {
+            return `"Variable \\\"var1\\\" type mismatch: the variable type \\\"List(${groups.type1})\\\" is not compatible with the argument type \\\"NonNull(List(${groups.type2}))\\\""`
+        }
+    },
+    {
+        "regex": /^"Variable \\\"\$var1\\\" of type \\\"\[(?<type1>[a-zA-Z]+)\]\!\\\" used in position expecting type \\\"\[(?<type2>[a-zA-Z]+)\!\]\\\"\."$/,
+        "return": function(groups) {
+            return `"Variable \\\"var1\\\" type mismatch: the variable type \\\"NonNull(List(${groups.type1}))\\\" is not compatible with the argument type \\\"List(NonNull(${groups.type2}))\\\""`
+        }
+    },
+    {
+        "regex": /^"Argument \\\"arg1\\\" of non-null type \\\"(?<type1>[a-zA-Z]+)\!\\\" must not be null\."$/,
+        "return": function(groups) {
+            return `"Expected non-null for \\\"NonNull(${groups.type1})\\\", got null"`
+        }
+    },
+    {
+        "regex": /^"Argument \\\"arg1\\\" of non-null type \\\"\[(?<type1>[a-zA-Z]+)\]\!\\\" must not be null\."$/,
+        "return": function(groups) {
+            return `"Expected non-null for \\\"NonNull(List(${groups.type1}))\\\", got null"`
+        }
+    },
+    {
+        "regex": /^"Argument \\\"arg1\\\" of non-null type \\\"\[(?<type1>[a-zA-Z]+)\!\]\!\\\" must not be null\."$/,
+        "return": function(groups) {
+            return `"Expected non-null for \\\"NonNull(List(NonNull(${groups.type1})))\\\", got null"`
+        }
+    },
+    {
+        "regex": /^"Variable \\\"\$var1\\\" of type \\\"\[(?<type1>[a-zA-Z]+)\]\\\" used in position expecting type \\\"\[(?<type2>[a-zA-Z]+)\!\]\\\"\."$/,
+        "return": function(groups) {
+            return `"Variable \\\"var1\\\" type mismatch: the variable type \\\"List(${groups.type1})\\\" is not compatible with the argument type \\\"List(NonNull(${groups.type2}))\\\""`
+        }
+    },
+]
+
+function JS_to_Lua_error_map_func(s) {
+    let j = 0
+    for (j = 0; j < Lua_to_JS_error.length; j++) {
+        let found = s.match(Lua_to_JS_error[j].regex)
+
+        if (found) {
+            return Lua_to_JS_error[j].return(found.groups)
+        }
+    }
+
+    return s
+}
+
+// == Build JS GraphQL objects ==
+
+function get_JS_type_name(type) {
+    if (type == 'list') {
+        return 'list'
+    }
+
+    if (graphql_types[type]) {
+        return graphql_types[type].var_type
+    }
+
+    return undefined
+}
+
+function get_JS_type_schema(type, inner_type) {
+    if (inner_type !== null) {
+        if (graphql_types[inner_type].graphql_type) {
+            return graphql_types[inner_type].graphql_type
+        }
+        
+        return ''
+    }
+
+    if (graphql_types[type]) {
+        if (graphql_types[type].graphql_type) {
+            return graphql_types[type].graphql_type
+        }
+        return ''
+    }
+
+    return ''
+}
+
+function get_JS_nullability(nullability) {
+    if (nullability == NonNullable) {
+        return `!`
+    } else {
+        return ``
+    }
+}
+
+function get_JS_type(type, nullability,
+                     inner_type, inner_nullability) {
+    let js_type = get_JS_type_name(type)
+    let js_nullability = get_JS_nullability(nullability)
+    let js_inner_type = get_JS_type_name(inner_type)
+    let js_inner_nullability = get_JS_nullability(inner_nullability)
+
+    if (js_type === 'list') {
+        return `[${js_inner_type}${js_inner_nullability}]${js_nullability}`
+    } else {
+        return `${js_type}${js_nullability}`
+    }
+}
+
+function get_JS_value(type, inner_type, value, plain_nil_as_null) {
+    if (Array.isArray(value)) {
+        if (value[0] === nil) {
+            return `[]`
+        } else if (value[0] === box.NULL) {
+            return `[null]`
+        } else {
+            if (inner_type == 'enum') {
+                return `[${value}]`
+            }
+            return JSON.stringify(value)
+        }
+    } else {
+        if (value === nil) {
+            if (plain_nil_as_null) {
+                return `null`
+            } else {
+                return ``
+            }
+        } else if (value === box.NULL) {
+            return `null`
+        } else {
+            if (type == 'enum') {
+                return value
+            }
+            return JSON.stringify(value)
+        }
+    }
+}
+
+function get_JS_default_value(type, inner_type, value) {
+    return get_JS_value(type, inner_type, value, false)
+}
+
+function get_JS_argument_value(type, inner_type, value) {
+    return get_JS_value(type, inner_type, value, true)
+}
+
+function build_schema(argument_type, argument_nullability,
+                      argument_inner_type, argument_inner_nullability, 
+                      argument_value,
+                      variable_type, variable_nullability,
+                      variable_inner_type, variable_inner_nullability, 
+                      variable_value, variable_default) {
+    let argument_str = get_JS_type(argument_type, argument_nullability,
+                                   argument_inner_type, argument_inner_nullability)
+    let additional_schema = get_JS_type_schema(argument_type, argument_inner_type)
+
+    var schema_str = `${additional_schema}
+        type result {
+          arg1: ${argument_str}
+        }
+
+        type Query {
+          test(arg1: ${argument_str}): result
+        }
+    `
+
+  return schema_str;
+};
+
+function build_query(argument_type, argument_nullability,
+                     argument_inner_type, argument_inner_nullability, 
+                     argument_value,
+                     variable_type, variable_nullability,
+                     variable_inner_type, variable_inner_nullability, 
+                     variable_value, variable_default) {
+    if (variable_type !== null) {
+        let variable_str = get_JS_type(variable_type, variable_nullability,
+                                       variable_inner_type, variable_inner_nullability)
+
+        let default_str = ``
+        let js_variable_default = get_JS_default_value(variable_type, variable_inner_type, variable_default)
+        if (js_variable_default !== ``) {
+            default_str = ` = ${js_variable_default}`
+        }
+
+        return `query MyQuery($var1: ${variable_str}${default_str}) { test(arg1: $var1) { arg1 } }`
+    } else {
+        let js_argument_value = get_JS_argument_value(argument_type, argument_inner_type, argument_value)
+        return `query MyQuery { test(arg1: ${js_argument_value}) { arg1 } }`
+    }
+};
+
+function build_variables(argument_type, argument_nullability,
+                         argument_inner_type, argument_inner_nullability, 
+                         argument_value,
+                         variable_type, variable_nullability,
+                         variable_inner_type, variable_inner_nullability, 
+                         variable_value, variable_default) {
+    let variables = [];
+
+    if (Array.isArray(variable_value)) {
+        if (variable_value[0] == nil) {
+            return {var1: []}
+        } else if (variable_value[0] === box.NULL) {
+            return {var1: [null]}
+        } else {
+            return {var1: variable_value}
+        }
+    }
+
+    if (variable_value !== nil) {
+        if (variable_value === box.NULL) {
+            return {var1: null}
+        } else {
+            return {var1: variable_value}
+        }
+    }
+
+    return []
+}
+
+var rootValue = {
+    test: (args) => {
+        return args;
+    },
+};
+
+// == Build Lua GraphQL objects ==
+
+var test_header = `-- THIS FILE WAS GENERATED AUTOMATICALLY
+-- See generator script at tests/integration/codegen/fuzzing_nullability
+-- This test compares library behaviour with reference JavaScript GraphQL
+-- implementation. Do not change it manually if the behaviour has changed,
+-- please interact with code generation script.
+
+local json = require('json')
+local types = require('graphql.types')
+
+local t = require('luatest')
+local g = t.group('fuzzing_nullability')
+
+local helpers = require('test.helpers')
+
+-- constants
+local Nullable = true
+local NonNullable = false
+
+-- custom types
+local my_enum = types.enum({
+    name = 'MyEnum',
+    values = {
+        a = { value = 'a' },
+        b = { value = 'b' },
+    },
+})
+
+local graphql_types = {
+    ['boolean_true'] = {
+        graphql_type = types.boolean,
+        var_type = 'Boolean',
+        value = true,
+        default = false,
+    },
+    ['boolean_false'] = {
+        graphql_type = types.boolean,
+        var_type = 'Boolean',
+        value = false,
+        default = true,
+    },
+    ['string'] = {
+        graphql_type = types.string,
+        var_type = 'String',
+        value = 'Test string',
+        default = 'Default Test string',
+    },
+    ['float'] = {
+        graphql_type = types.float,
+        var_type = 'Float',
+        value = 1.1111111,
+        default = 0,
+    },
+    ['int'] = {
+        graphql_type = types.int,
+        var_type = 'Int',
+        value = 2^30,
+        default = 0,
+    },
+    ['id'] = {
+        graphql_type = types.id,
+        var_type = 'ID',
+        value = '00000000-0000-0000-0000-000000000000',
+        default = '11111111-1111-1111-1111-111111111111',
+    },
+    ['enum'] = {
+        graphql_type = my_enum,
+        var_type = 'MyEnum',
+        value = 'b',
+        default = 'a',
+    },
+    -- For more types follow https://github.com/tarantool/graphql/issues/63
+}
+
+local function build_schema(argument_type, argument_nullability,
+                            argument_inner_type, argument_inner_nullability,
+                            argument_value,
+                            variable_type, variable_nullability,
+                            variable_inner_type, variable_inner_nullability,
+                            variable_value, variable_default)
+    local type
+    if argument_type == 'list' then
+        if argument_inner_nullability == NonNullable then
+            type = types.list(types.nonNull(graphql_types[argument_inner_type].graphql_type))
+        else
+            type = types.list(graphql_types[argument_inner_type].graphql_type)
+        end
+        if argument_nullability == NonNullable then
+            type = types.nonNull(type)
+        end
+    else
+        if argument_nullability == NonNullable then
+            type = types.nonNull(graphql_types[argument_type].graphql_type)
+        else
+            type = graphql_types[argument_type].graphql_type
+        end
+    end
+
+    return {
+        ['test'] = {
+            kind = types.object({
+                name = 'result',
+                fields = {arg1 = type}
+            }),
+            arguments = {arg1 = type},
+            resolve = function(_, args)
+                return args
+            end,
+        }
+    }
+end
+
+-- For more test cases follow https://github.com/tarantool/graphql/issues/63`
+console.log(test_header)
+
+function to_Lua(v) {
+    if (v === null) {
+        return `nil`
+    }
+
+    if (v === nil) {
+        return `${v}`
+    }
+
+    if (v === box.NULL) {
+        return `${v}`
+    }
+
+    if (v === Nullable) {
+        return `${v}`
+    }
+
+    if (v === NonNullable) {
+        return `${v}`
+    }
+
+    if (Array.isArray(v)) {
+        if (v[0] === nil) {
+            return '{}'
+        } else if (v[0] === box.NULL) {
+            return '{box.NULL}'
+        } else {
+            if (typeof v[0] === 'string' ) {
+                return `{'${v[0]}'}`
+            }
+
+            return `{${v}}`
+        }
+    }
+
+    if (typeof v === 'string' ) {
+        return `'${v}'`
+    }
+
+    return `${v}`
+}
+
+function build_test_case(response, suite_name, i,
+                         argument_type, argument_nullability,
+                         argument_inner_type, argument_inner_nullability, 
+                         argument_value,
+                         variable_type, variable_nullability,
+                         variable_inner_type, variable_inner_nullability, 
+                         variable_value, variable_default,
+                         query, schema_str) {
+    let expected_data
+
+    if (response.hasOwnProperty('data')) {
+        let _expected_data = JSON.stringify(response.data)
+        expected_data = `'${_expected_data}'`
+    } else {
+        expected_data = `nil`
+    }
+
+    let expected_error
+
+    if (response.hasOwnProperty('errors')) {
+        let _expected_error = JSON.stringify(response.errors[0].message)
+        expected_error = JS_to_Lua_error_map_func(`${_expected_error}`)
+    } else {
+        expected_error = `nil`
+    }
+
+    let Lua_argument_type = to_Lua(argument_type)
+    let Lua_argument_nullability = to_Lua(argument_nullability)
+    let Lua_argument_inner_type = to_Lua(argument_inner_type)
+    let Lua_argument_inner_nullability = to_Lua(argument_inner_nullability)
+
+    let Lua_variable_type = to_Lua(variable_type)
+    let Lua_variable_nullability = to_Lua(variable_nullability)
+    let Lua_variable_inner_type = to_Lua(variable_inner_type)
+    let Lua_variable_inner_nullability = to_Lua(variable_inner_nullability)
+
+
+    let Lua_variable_default = to_Lua(variable_default)
+    let Lua_argument_value = to_Lua(argument_value)
+    let Lua_variable_value = to_Lua(variable_value)
+
+    let type_in_name
+    if (argument_inner_type !== null) {
+        type_in_name = argument_inner_type
+    } else {
+        type_in_name = argument_type
+    }
+
+    return `
+g.test_${suite_name}_${type_in_name}_${i} = function(g)
+    local argument_type = ${Lua_argument_type}
+    local argument_nullability = ${Lua_argument_nullability}
+    local argument_inner_type = ${Lua_argument_inner_type}
+    local argument_inner_nullability = ${Lua_argument_inner_nullability}
+    local argument_value = ${Lua_argument_value}
+    local variable_type = ${Lua_variable_type}
+    local variable_nullability = ${Lua_variable_nullability}
+    local variable_inner_type = ${Lua_variable_inner_type}
+    local variable_inner_nullability = ${Lua_variable_inner_nullability}
+    local variable_default = ${Lua_variable_default}
+    local variable_value = ${Lua_variable_value}
+
+    local query_schema = build_schema(argument_type, argument_nullability,
+                                      argument_inner_type, argument_inner_nullability,
+                                      argument_value,
+                                      variable_type, variable_nullability,
+                                      variable_inner_type, variable_inner_nullability,
+                                      variable_value, variable_default)
+
+    -- There is no explicit check that Lua query_schema is the same as JS query_schema.
+    local reference_schema = [[${schema_str}]]
+
+    local query = '${query}'
+
+    local ok, res = pcall(helpers.check_request, query, query_schema, nil, nil, { variables = { var1 = variable_value }})
+
+    local result, err
+    if ok then
+        result = json.encode(res)
+    else
+        err = res
+    end
+
+    local expected_data_json = ${expected_data}
+    local expected_error_json = ${expected_error}
+
+    if expected_error_json ~= nil and expected_data_json ~= nil then
+        t.assert_equals(err, expected_error_json)
+        t.xfail('See https://github.com/tarantool/graphql/issues/62')
+    end
+
+    t.assert_equals(result, expected_data_json)
+    t.assert_equals(err, expected_error_json)
+end`
+}
+
+async function build_suite(suite_name,
+                     argument_type, argument_nullabilities,
+                     argument_inner_type, argument_inner_nullabilities,
+                     argument_values,
+                     variable_type, variable_nullabilities,
+                     variable_inner_type, variable_inner_nullabilities,
+                     variable_values,
+                     variable_defaults) {
+    let i = 0
+
+    if (argument_inner_nullabilities.length == 0) {
+        // Non-list case
+        let argument_inner_nullability = null
+        let variable_inner_nullability = null
+
+        if (variable_type == null) {
+            // No variables case
+            let variable_nullability = null
+            let variable_value = null
+            let variable_default = null
+
+            argument_nullabilities.forEach( async function (argument_nullability) {
+                argument_values.forEach( async function (argument_value)  {
+                    let schema_str = build_schema(argument_type, argument_nullability,
+                                              argument_inner_type, argument_inner_nullability,
+                                              argument_value,
+                                              variable_type, variable_nullability,
+                                              variable_inner_type, variable_inner_nullability,
+                                              variable_value, variable_default)
+                    let schema = buildSchema(schema_str)
+
+                    let query = build_query(argument_type, argument_nullability,
+                                            argument_inner_type, argument_inner_nullability, 
+                                            argument_value,
+                                            variable_type, variable_nullability,
+                                            variable_inner_type, variable_inner_nullability, 
+                                            variable_value, variable_default)
+                    
+
+                    await graphql({
+                        schema,
+                        source: query,
+                        rootValue,
+                    }).then((response) => {
+                        i = i + 1
+                        console.log(build_test_case(response, suite_name, i,
+                                               argument_type, argument_nullability,
+                                               argument_inner_type, argument_inner_nullability, 
+                                               argument_value,
+                                               variable_type, variable_nullability,
+                                               variable_inner_type, variable_inner_nullability, 
+                                               variable_value, variable_default,
+                                               query, schema_str))
+                    })
+                })
+            })
+        } else {
+            // Variables case
+            argument_nullabilities.forEach( async function (argument_nullability) {
+                variable_nullabilities.forEach( async function (variable_nullability)  {
+                    variable_values.forEach( async function (variable_value)  {
+                        variable_defaults.forEach( async function (variable_default)  {
+                            let argument_value = null
+
+                            let schema_str = build_schema(argument_type, argument_nullability,
+                                                      argument_inner_type, argument_inner_nullability, 
+                                                      argument_value,
+                                                      variable_type, variable_nullability,
+                                                      variable_inner_type, variable_inner_nullability, 
+                                                      variable_value, variable_default)
+                            let schema = buildSchema(schema_str)
+
+                            let query = build_query(argument_type, argument_nullability,
+                                                    argument_inner_type, argument_inner_nullability, 
+                                                    argument_value,
+                                                    variable_type, variable_nullability,
+                                                    variable_inner_type, variable_inner_nullability, 
+                                                    variable_value, variable_default)
+
+                            let variables = build_variables(argument_type, argument_nullability,
+                                                            argument_inner_type, argument_inner_nullability, 
+                                                            argument_value,
+                                                            variable_type, variable_nullability,
+                                                            variable_inner_type, variable_inner_nullability, 
+                                                            variable_value, variable_default)
+                            
+
+                            await graphql({
+                                schema,
+                                source: query,
+                                rootValue,
+                                variableValues: variables
+                            }).then((response) => {
+                                i = i + 1
+                                console.log(build_test_case(response, suite_name, i,
+                                                            argument_type, argument_nullability,
+                                                            argument_inner_type, argument_inner_nullability, 
+                                                            argument_value,
+                                                            variable_type, variable_nullability,
+                                                            variable_inner_type, variable_inner_nullability, 
+                                                            variable_value, variable_default,
+                                                            query, schema_str))
+                            })
+                        })
+                    })
+                })
+            })
+        }
+
+        return
+    }
+
+    // List case
+    if (variable_type == null) {
+        argument_nullabilities.forEach( async function (argument_nullability) {
+            argument_inner_nullabilities.forEach( async function (argument_inner_nullability) {
+                argument_values.forEach( async function (argument_value)  {
+                    let variable_nullability = null
+                    let variable_inner_nullability = null
+                    let variable_value = null
+                    let variable_default = null
+
+                    let schema_str = build_schema(argument_type, argument_nullability,
+                                              argument_inner_type, argument_inner_nullability, 
+                                              argument_value,
+                                              variable_type, variable_nullability,
+                                              variable_inner_type, variable_inner_nullability, 
+                                              variable_value, variable_default)
+                    let schema = buildSchema(schema_str)
+
+                    let query = build_query(argument_type, argument_nullability,
+                                            argument_inner_type, argument_inner_nullability, 
+                                            argument_value,
+                                            variable_type, variable_nullability,
+                                            variable_inner_type, variable_inner_nullability, 
+                                            variable_value, variable_default)
+                    
+                    await graphql({
+                        schema,
+                        source: query,
+                        rootValue,
+                    }).then((response) => {
+                        i = i + 1
+                        console.log(build_test_case(response, suite_name, i,
+                                                    argument_type, argument_nullability,
+                                                    argument_inner_type, argument_inner_nullability, 
+                                                    argument_value,
+                                                    variable_type, variable_nullability,
+                                                    variable_inner_type, variable_inner_nullability, 
+                                                    variable_value, variable_default,
+                                                    query, schema_str))
+                    })
+                })
+            })
+        })
+    } else {
+        argument_nullabilities.forEach( async function (argument_nullability) {
+            argument_inner_nullabilities.forEach( async function (argument_inner_nullability) {
+                variable_nullabilities.forEach( async function (variable_nullability) {
+                    variable_inner_nullabilities.forEach( async function (variable_inner_nullability) {
+                        variable_values.forEach( async function (variable_value)  {
+                            variable_defaults.forEach( async function (variable_default)  {
+                                let argument_value = null
+
+                                let schema_str = build_schema(argument_type, argument_nullability,
+                                                          argument_inner_type, argument_inner_nullability, 
+                                                          argument_value,
+                                                          variable_type, variable_nullability,
+                                                          variable_inner_type, variable_inner_nullability, 
+                                                          variable_value, variable_default)
+                                let schema = buildSchema(schema_str)
+
+                                let query = build_query(argument_type, argument_nullability,
+                                                        argument_inner_type, argument_inner_nullability, 
+                                                        argument_value,
+                                                        variable_type, variable_nullability,
+                                                        variable_inner_type, variable_inner_nullability, 
+                                                        variable_value, variable_default)
+
+                                let variables = build_variables(argument_type, argument_nullability,
+                                                                argument_inner_type, argument_inner_nullability, 
+                                                                argument_value,
+                                                                variable_type, variable_nullability,
+                                                                variable_inner_type, variable_inner_nullability, 
+                                                                variable_value, variable_default)
+                                    
+                                await graphql({
+                                    schema,
+                                    source: query,
+                                    rootValue,
+                                    variableValues: variables
+                                }).then((response) => {
+                                    i = i + 1
+                                    console.log(build_test_case(response, suite_name, i,
+                                                                argument_type, argument_nullability,
+                                                                argument_inner_type, argument_inner_nullability, 
+                                                                argument_value,
+                                                                variable_type, variable_nullability,
+                                                                variable_inner_type, variable_inner_nullability, 
+                                                                variable_value, variable_default,
+                                                                query, schema_str))
+                                })
+                            })
+                        })
+                    })
+                })
+            })
+        })
+    }
+}
+
+let type
+let type_desc
+
+// == Non-list argument nullability ==
+// 
+// There is no way pass no value to the argument
+// since `test(arg1)` is invalid syntax.
+// We use `test(arg1: null)` for both nil and box.NULL,
+// so the behavior will be the same for them.
+
+Object.keys(graphql_types).forEach( (type) => {
+    let type_desc = graphql_types[type]
+
+    build_suite('nonlist_argument_nullability',
+                type, [Nullable, NonNullable],
+                null, [],
+                [nil, box.NULL, type_desc.value],
+                null, [],
+                null, [],
+                [],
+                [])
+})
+
+// == List argument nullability ==
+// 
+// {nil} is the same as {} in Lua.
+
+Object.keys(graphql_types).forEach( (type) => {
+    let type_desc = graphql_types[type]
+
+    build_suite('list_argument_nullability',
+                'list', [Nullable, NonNullable],
+                type, [Nullable, NonNullable],
+                [nil, box.NULL, [nil], [box.NULL], [type_desc.value]],
+                null, [],
+                null, [],
+                [],
+                [])
+})
+
+// == Non-list argument with variable nullability ==
+
+Object.keys(graphql_types).forEach( (type) => {
+    let type_desc = graphql_types[type]
+
+    build_suite('nonlist_argument_with_variables_nullability',
+                type, [Nullable, NonNullable],
+                null, [],
+                [],
+                type, [Nullable, NonNullable],
+                null, [],
+                [nil, box.NULL, type_desc.value],
+                [nil, box.NULL, type_desc.default])
+})
+
+// == List argument with variable nullability ==
+// 
+// {nil} is the same as {} in Lua.
+
+Object.keys(graphql_types).forEach( (type) => {
+    let type_desc = graphql_types[type]
+
+
+    build_suite('list_argument_with_variables_nullability',
+                'list', [Nullable, NonNullable],
+                type, [Nullable, NonNullable],
+                [],
+                'list', [Nullable, NonNullable],
+                type, [Nullable, NonNullable],
+                [nil, box.NULL, [nil], [box.NULL], [type_desc.value]],
+                [nil, box.NULL, [nil], [box.NULL], [type_desc.default]])
+})

--- a/test/integration/codegen/fuzzing_nullability/package-lock.json
+++ b/test/integration/codegen/fuzzing_nullability/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "fuzzing_nullability",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "graphql": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
+    }
+  }
+}

--- a/test/integration/codegen/fuzzing_nullability/package.json
+++ b/test/integration/codegen/fuzzing_nullability/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fuzzing_nullability",
+  "version": "1.0.0",
+  "description": "",
+  "main": "generate.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "graphql": "^15.8.0"
+  }
+}


### PR DESCRIPTION
Reworked and improved version of https://github.com/tarantool/graphql/pull/59

Compare library with JS reference implementation in various nullability cases. This PR uses JS script to build various schemas and queries and execute them to generate luatest script that verifies that this library has the same behavior.

To generate script, run
```bash
cd ./tests/integration/codegen/fuzzing_nullability
npm install
node ./generate.js > ../../fuzzing_nullability_test.lua
```

This PR fixed several nullability behavior issues. There is some case that isn't yet fully covered by our library, refer to https://github.com/tarantool/graphql/issues/62 for updates.

Follow https://github.com/tarantool/graphql/issues/63 for more test cases.