### PR TITLE
api: add hardcoded versioning support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,16 @@ on:
     tags: ['*']
 
 jobs:
+  version-check:
+    # We need this job to run only on push with tag.
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check module version
+        uses: tarantool/actions/check-module-version@master
+        with:
+          module-name: 'graphql'
+
   publish-rockspec-scm-1:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
@@ -18,6 +28,7 @@ jobs:
 
   publish-rockspec-tag:
     if: startsWith(github.ref, 'refs/tags/')
+    needs: version-check
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +37,6 @@ jobs:
           tarantool-version: '2.8'
 
       - run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
-      - run: echo "return {VERSION = '"$TAG"'}" > graphql/init.lua
       - run: tarantoolctl rocks new_version --tag $TAG
       - run: tarantoolctl rocks make graphql-$TAG-1.rockspec
       - run: tarantoolctl rocks pack graphql $TAG

--- a/graphql-scm-1.rockspec
+++ b/graphql-scm-1.rockspec
@@ -21,6 +21,7 @@ build = {
   type = 'builtin',
   modules = {
     ['graphql.init'] = 'graphql/init.lua',
+    ['graphql.version'] = 'graphql/version.lua',
     ['graphql.execute'] = 'graphql/execute.lua',
     ['graphql.introspection'] = 'graphql/introspection.lua',
     ['graphql.parse'] = 'graphql/parse.lua',

--- a/graphql/init.lua
+++ b/graphql/init.lua
@@ -1,1 +1,6 @@
-return {VERSION = 'unknown'}
+local VERSION = require('graphql.version')
+
+return {
+    VERSION = VERSION,
+    _VERSION = VERSION,
+}

--- a/graphql/version.lua
+++ b/graphql/version.lua
@@ -1,0 +1,4 @@
+-- Сontains the module version.
+-- Requires manual update in case of release commit.
+
+return '0.2.0'

--- a/test/unit/graphql_test.lua
+++ b/test/unit/graphql_test.lua
@@ -1090,7 +1090,7 @@ function g.test_util_find_by_name()
 end
 
 g.test_version = function()
-    t.assert_type(require('graphql').VERSION, 'string')
+    t.assert_type(require('graphql')._VERSION, 'string')
 end
 
 function g.test_is_array()


### PR DESCRIPTION
Added the _VERSION variable to the exported table. Is part of the task [1].