### PR TITLE
api: deprecate VERSION handle

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: tarantool/rocks.tarantool.org/github-action@master
         with:
           auth: ${{ secrets.ROCKS_AUTH }}
@@ -31,10 +31,10 @@ jobs:
     needs: version-check
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: tarantool/setup-tarantool@v1
+      - uses: actions/checkout@v3
+      - uses: tarantool/setup-tarantool@v2
         with:
-          tarantool-version: '2.8'
+          tarantool-version: '2.10'
 
       - run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - run: tarantoolctl rocks new_version --tag $TAG

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -11,12 +11,12 @@ jobs:
       github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != 'tarantool'
     strategy:
       matrix:
-        tarantool-version: ["1.10", "2.8"]
+        tarantool-version: ["1.10", "2.10"]
       fail-fast: false
     runs-on: [ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v2
-      - uses: tarantool/setup-tarantool@v1
+      - uses: actions/checkout@v3
+      - uses: tarantool/setup-tarantool@v2
         with:
           tarantool-version: ${{ matrix.tarantool-version }}
 

--- a/graphql/init.lua
+++ b/graphql/init.lua
@@ -1,6 +1,17 @@
+local log = require('log')
+
 local VERSION = require('graphql.version')
 
-return {
-    VERSION = VERSION,
+return setmetatable({
     _VERSION = VERSION,
-}
+}, {
+    __index = function(_, key)
+        if key == 'VERSION' then
+            log.warn("require('graphql').VERSION is deprecated, " ..
+                     "use require('graphql')._VERSION instead.")
+            return VERSION
+        end
+
+        return nil
+    end
+})

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -1,3 +1,7 @@
+local clock = require('clock')
+local fiber = require('fiber')
+local log = require('log')
+
 local types = require('graphql.types')
 local schema = require('graphql.schema')
 local parse = require('graphql.parse')
@@ -31,6 +35,32 @@ function helpers.check_request(query, query_schema, mutation_schema, directives,
     local rootValue = {}
     local variables = opts.variables or {}
     return execute.execute(compiled_schema, parsed, rootValue, variables)
+end
+
+-- Based on https://github.com/tarantool/crud/blob/5717e87e1f8a6fb852c26181524fafdbc7a472d8/test/helper.lua#L533-L544
+function helpers.fflush_main_server_output(server, capture)
+    -- Sometimes we have a delay here. This hack helps to wait for the end of
+    -- the output. It shouldn't take much time.
+    local helper_msg = "metrics fflush message"
+    if server then
+        server.net_box:eval([[
+            require('log').error(...)
+        ]], {helper_msg})
+    else
+        log.error(helper_msg)
+    end
+
+    local max_wait_timeout = 10
+    local start_time = clock.monotonic()
+
+    local captured = ""
+    while (not string.find(captured, helper_msg, 1, true))
+    and (clock.monotonic() - start_time < max_wait_timeout) do
+        local captured_part = capture:flush()
+        captured = captured .. (captured_part.stdout or "") .. (captured_part.stderr or "")
+        fiber.yield()
+    end
+    return captured
 end
 
 return helpers

--- a/test/unit/graphql_test.lua
+++ b/test/unit/graphql_test.lua
@@ -1,5 +1,8 @@
 local t = require('luatest')
+local luatest_capture = require('luatest.capture')
 local g = t.group('unit')
+
+local helpers = require('test.helpers')
 
 local parse = require('graphql.parse').parse
 local types = require('graphql.types')
@@ -1091,6 +1094,20 @@ end
 
 g.test_version = function()
     t.assert_type(require('graphql')._VERSION, 'string')
+end
+
+g.test_deprecated_version = function()
+    local capture = luatest_capture:new()
+    capture:enable()
+
+    t.assert_type(require('graphql').VERSION, 'string')
+    local stdout = helpers.fflush_main_server_output(nil, capture)
+    capture:disable()
+
+    t.assert_str_contains(
+        stdout,
+        "require('graphql').VERSION is deprecated, " ..
+        "use require('graphql')._VERSION instead.")
 end
 
 function g.test_is_array()


### PR DESCRIPTION
VERSION module version extraction API is replaced with _VERSION, which has been chosen to be the new standard.