### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.3.1] - 2025-10-27
+
+This release introduces bumped luagraphqlparser version to avoid
+compatibility problem with CMake 4.x.
+
+### Changed
+
+- Bump luagraphqlparser to 0.2.1 (#69).

--- a/graphql/version.lua
+++ b/graphql/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '0.3.0'
+return '0.3.1'


### PR DESCRIPTION
This release introduces bumped luagraphqlparser version to solve
compatibility problem with CMake 4.x.

### Changed

- Bump luagraphqlparser to 0.2.1 (#69).
